### PR TITLE
Add startTime parameter to createWorklog and related functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Parameters:
 - timeSpentHours: Number (positive)
 - date: String (YYYY-MM-DD)
 - description: String (optional)
+- startTime: String (HH:MM format, optional)
 ```
 
 ### bulkCreateWorklogs
@@ -177,6 +178,7 @@ Parameters:
     timeSpentHours: Number
     date: String (YYYY-MM-DD)
     description: String (optional)
+    startTime: String (HH:MM format, optional)
   }
 ```
 
@@ -190,6 +192,7 @@ Parameters:
 - timeSpentHours: Number (positive)
 - description: String (optional)
 - date: String (YYYY-MM-DD, optional)
+- startTime: String (HH:MM format, optional)
 ```
 
 ### deleteWorklog

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,9 @@ server.tool(
 server.tool(
   'createWorklog',
   createWorklogSchema.shape,
-  async ({ issueKey, timeSpentHours, date, description }) => {
+  async ({ issueKey, timeSpentHours, date, description, startTime }) => {
     try {
-      const result = await tools.createWorklog(issueKey, timeSpentHours, date, description);
+      const result = await tools.createWorklog(issueKey, timeSpentHours, date, description, startTime);
       return {
         content: result.content
       };
@@ -87,9 +87,9 @@ server.tool(
 server.tool(
   'editWorklog',
   editWorklogSchema.shape,
-  async ({ worklogId, timeSpentHours, description, date }) => {
+  async ({ worklogId, timeSpentHours, description, date, startTime }) => {
     try {
-      const result = await tools.editWorklog(worklogId, timeSpentHours, description || null, date || null);
+      const result = await tools.editWorklog(worklogId, timeSpentHours, description || null, date || null, startTime || undefined);
       return {
         content: result.content
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 // Common validation schemas
 export const dateSchema = () => z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format');
+export const timeSchema = () => z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'Time must be in HH:MM format');
 export const issueKeySchema = () => z.string().min(1, 'Issue key cannot be empty');
 export const issueIdSchema = () => z.union([
   z.string().min(1, 'Issue ID cannot be empty'),
@@ -24,6 +25,7 @@ export const worklogEntrySchema = z.object({
   timeSpentHours: z.number().positive('Time spent must be positive'),
   date: dateSchema(),
   description: z.string().optional(),
+  startTime: timeSchema().optional(),
 });
 
 export type WorklogEntry = z.infer<typeof worklogEntrySchema>;
@@ -39,6 +41,7 @@ export const createWorklogSchema = z.object({
   timeSpentHours: z.number().positive('Time spent must be positive'),
   date: dateSchema(),
   description: z.string().optional().default(''),
+  startTime: timeSchema().optional(),
 });
 
 export const bulkCreateWorklogsSchema = z.object({
@@ -50,6 +53,7 @@ export const editWorklogSchema = z.object({
   timeSpentHours: z.number().positive('Time spent must be positive'),
   description: z.string().optional().nullable(),
   date: dateSchema().optional().nullable(),
+  startTime: timeSchema().optional(),
 });
 
 export const deleteWorklogSchema = z.object({
@@ -95,6 +99,8 @@ export interface WorklogResult {
   date: string;
   worklogId: string | null;
   success: boolean;
+  startTime?: string;
+  endTime?: string;
 }
 
 export interface WorklogError {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,4 +40,28 @@ export async function getIssueKeysMap(worklogs: any[]): Promise<Record<string, s
   }));
   
   return issueIdToKeyMap;
+}
+
+/**
+ * Calculate end time
+ * Calculates the end time based on the start time and hours spent
+ * @param startTime Time in format HH:MM
+ * @param hoursSpent Duration in hours (can be decimal)
+ * @returns End time in format HH:MM
+ */
+export function calculateEndTime(startTime: string, hoursSpent: number): string {
+  // Parse the HH:MM format
+  const [hours, minutes] = startTime.split(':').map(num => parseInt(num, 10));
+  
+  // Create a Date object with today's date but with the given hours and minutes
+  const startTimeDate = new Date();
+  startTimeDate.setHours(hours, minutes, 0, 0);
+  
+  // Add the duration in milliseconds
+  const endTimeDate = new Date(startTimeDate.getTime() + (hoursSpent * 3600 * 1000));
+  
+  // Format the end time as HH:MM
+  const endTime = `${endTimeDate.getHours().toString().padStart(2, '0')}:${endTimeDate.getMinutes().toString().padStart(2, '0')}`;
+  
+  return endTime;
 } 


### PR DESCRIPTION
This PR adds the ability to set a startTime when creating worklogs through the Tempo API.

Changes:
- Add startTime parameter to createWorklog
- Add startTime to bulkCreateWorklogs entries
- Add startTime to editWorklog
- Create timeSchema for time format validation
- Add endTime calculation utility function
- Show the calculated end time in respownses
- Update documentation in README.md

This addresses issue #1 by allowing users to set a precise start time for their worklogs, making the time tracking more accurate. 