### PR TITLE
fix: append :00 seconds to startTime for Tempo API v4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,10 @@ Creates a new worklog for a specific Jira issue.
 ```
 Parameters:
 - issueKey: String (e.g., "PROJECT-123")
-- timeSpentHours: Number (positive)
+- timeSpentHours: Number (positive, must be in quarter-hour increments: 0.25, 0.5, 0.75, 1, 1.25, etc.)
 - date: String (YYYY-MM-DD)
 - description: String (optional)
-- startTime: String (HH:MM format, optional)
+- startTime: String (HH:MM format with 15-minute increments: :00, :15, :30, :45, optional)
 ```
 
 ### bulkCreateWorklogs
@@ -193,10 +193,10 @@ Creates multiple worklogs in a single operation.
 Parameters:
 - worklogEntries: Array of {
     issueKey: String
-    timeSpentHours: Number
+    timeSpentHours: Number (must be in quarter-hour increments: 0.25, 0.5, 0.75, 1, 1.25, etc.)
     date: String (YYYY-MM-DD)
     description: String (optional)
-    startTime: String (HH:MM format, optional)
+    startTime: String (HH:MM format with 15-minute increments: :00, :15, :30, :45, optional)
   }
 ```
 
@@ -207,10 +207,10 @@ Modifies an existing worklog.
 ```
 Parameters:
 - worklogId: String
-- timeSpentHours: Number (positive)
+- timeSpentHours: Number (positive, must be in quarter-hour increments: 0.25, 0.5, 0.75, 1, 1.25, etc.)
 - description: String (optional)
 - date: String (YYYY-MM-DD, optional)
-- startTime: String (HH:MM format, optional)
+- startTime: String (HH:MM format with 15-minute increments: :00, :15, :30, :45, optional)
 ```
 
 ### deleteWorklog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivelin-web/tempo-mcp-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "MCP server for managing Tempo worklogs in Jira",
   "main": "build/index.js",
   "type": "module",
@@ -32,6 +32,9 @@
     "ai"
   ],
   "author": "Ivelin Ivanov <ivelinivanov1999@gmail.com>",
+  "contributors": [
+    "Filip Kalný <c_fkalny@groupon.com>"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -133,7 +133,7 @@ export async function createWorklog(
       startDate: date,
       authorAccountId: accountId,
       description,
-      ...(startTime && { startTime }),
+      ...(startTime && { startTime: `${startTime}:00` }),
       ...(account && { attributes: [{ key: '_Account_', value: account.key }] })
     };
     
@@ -198,7 +198,7 @@ export async function bulkCreateWorklogs(
           startDate: entry.date,
           authorAccountId,
           description: entry.description || '',
-          ...(entry.startTime && { startTime: entry.startTime }),
+          ...(entry.startTime && { startTime: `${entry.startTime}:00` }),
           ...(account && { attributes: [{ key: '_Account_', value: account.key }] })
         }));
 
@@ -318,7 +318,7 @@ export async function editWorklog(
       timeSpentSeconds: Math.round(timeSpentHours * 3600),
       billableSeconds: Math.round(timeSpentHours * 3600),
       ...(description !== null && { description }),
-      ...(startTime && { startTime }),
+      ...(startTime && { startTime: `${startTime}:00` }),
     };
 
     // Update the worklog

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -84,10 +84,11 @@ export async function retrieveWorklogs(
       const description = worklog.description || 'No description';
       const timeSpentHours = (worklog.timeSpentSeconds / 3600).toFixed(2);
       const date = worklog.startDate || 'Unknown';
+      const startTime = worklog.startTime || '';
       
       return {
         type: "text" as const,
-        text: `IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date} | Hours: ${timeSpentHours} | Description: ${description}`
+        text: `IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date}${startTime ? ` | StartTime: ${startTime}` : ''} | Hours: ${timeSpentHours} | Description: ${description}`
       };
     });
     

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,11 @@ import { z } from 'zod';
 
 // Common validation schemas
 export const dateSchema = () => z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format');
-export const timeSchema = () => z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'Time must be in HH:MM format');
+export const timeSchema = () => z.string().regex(/^([01]\d|2[0-3]):(00|15|30|45)$/, 'Time must be in HH:MM format and in 15-minute increments');
+export const timeSpentHoursSchema = () => z.number().positive('Time spent must be positive').refine(
+  (val) => (val * 4) % 1 === 0,
+  'Time spent must be in quarter-hour increments (0.25, 0.5, 0.75, 1, 1.25, etc.)'
+);
 export const issueKeySchema = () => z.string().min(1, 'Issue key cannot be empty');
 export const issueIdSchema = () => z.union([
   z.string().min(1, 'Issue ID cannot be empty'),
@@ -27,7 +31,7 @@ export type Env = z.infer<typeof envSchema>;
 // Worklog entry schema
 export const worklogEntrySchema = z.object({
   issueKey: issueKeySchema(),
-  timeSpentHours: z.number().positive('Time spent must be positive'),
+  timeSpentHours: timeSpentHoursSchema(),
   date: dateSchema(),
   description: z.string().optional(),
   startTime: timeSchema().optional(),
@@ -43,7 +47,7 @@ export const retrieveWorklogsSchema = z.object({
 
 export const createWorklogSchema = z.object({
   issueKey: issueKeySchema(),
-  timeSpentHours: z.number().positive('Time spent must be positive'),
+  timeSpentHours: timeSpentHoursSchema(),
   date: dateSchema(),
   description: z.string().optional().default(''),
   startTime: timeSchema().optional(),
@@ -55,7 +59,7 @@ export const bulkCreateWorklogsSchema = z.object({
 
 export const editWorklogSchema = z.object({
   worklogId: z.string().min(1, 'Worklog ID is required'),
-  timeSpentHours: z.number().positive('Time spent must be positive'),
+  timeSpentHours: timeSpentHoursSchema(),
   description: z.string().optional().nullable(),
   date: dateSchema().optional().nullable(),
   startTime: timeSchema().optional(),


### PR DESCRIPTION
- Tempo API v4 requires time in HH:MM:SS format
- MCP accepts HH:MM format from users
- Automatically append :00 to convert HH:MM to HH:MM:SS
- Fixes 400 errors when creating/editing worklogs with startTime
- Add Filip Kalný as contributor
- Bump version to 1.2.1