### PR TITLE
feat: add tempoWorklogId to the retrieveWorklogs call

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -86,6 +86,7 @@ export async function retrieveWorklogs(
 
     // Format the response
     const formattedContent = worklogs.map((worklog: any) => {
+      const tempoWorklogId = worklog.tempoWorklogId || 'Unknown';
       const issueId = worklog.issue?.id || 'Unknown';
       const issueKey = issueIdToKeyMap[issueId] || 'Unknown';
       const description = worklog.description || 'No description';
@@ -94,7 +95,7 @@ export async function retrieveWorklogs(
 
       return {
         type: 'text' as const,
-        text: `IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date} | Hours: ${timeSpentHours} | Description: ${description}`,
+        text: `TempoWorklogId: ${tempoWorklogId} | IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date} | Hours: ${timeSpentHours} | Description: ${description}`,
       };
     });
 


### PR DESCRIPTION
Add `tempoWorklogId` to the text returned from `retrieveWorklogs`.

This is necessary since the `updateWorklog` and `deleteWorklog` both require the `tempoWorklogId` to be updated / deleted. By adding this we're able to first retrieve the `tempoWorklogId` and then update the worklog with the correct `tempoWorklogId`.

fixes #15 