### PR TITLE
feat: add Tempo API v4 time format support and startTime display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivelin-web/tempo-mcp-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "MCP server for managing Tempo worklogs in Jira",
   "main": "build/index.js",
   "type": "module",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -92,10 +92,11 @@ export async function retrieveWorklogs(
       const description = worklog.description || 'No description';
       const timeSpentHours = (worklog.timeSpentSeconds / 3600).toFixed(2);
       const date = worklog.startDate || 'Unknown';
+      const startTime = worklog.startTime || '';
 
       return {
         type: 'text' as const,
-        text: `TempoWorklogId: ${tempoWorklogId} | IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date} | Hours: ${timeSpentHours} | Description: ${description}`,
+        text: `TempoWorklogId: ${tempoWorklogId} | IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date}${startTime ? ` | StartTime: ${startTime}` : ''} | Hours: ${timeSpentHours} | Description: ${description}`,
       };
     });
 
@@ -146,7 +147,7 @@ export async function createWorklog(
       startDate: date,
       authorAccountId: accountId,
       description,
-      ...(startTime && { startTime }),
+      ...(startTime && { startTime: `${startTime}:00` }),
       ...(account && {
         attributes: [{ key: '_Account_', value: account.key }],
       }),
@@ -220,7 +221,7 @@ export async function bulkCreateWorklogs(
           startDate: entry.date,
           authorAccountId,
           description: entry.description || '',
-          ...(entry.startTime && { startTime: entry.startTime }),
+          ...(entry.startTime && { startTime: `${entry.startTime}:00` }),
           ...(account && {
             attributes: [{ key: '_Account_', value: account.key }],
           }),
@@ -363,7 +364,7 @@ export async function editWorklog(
       timeSpentSeconds: Math.round(timeSpentHours * 3600),
       billableSeconds: Math.round(timeSpentHours * 3600),
       ...(description !== null && { description }),
-      ...(startTime && { startTime }),
+      ...(startTime && { startTime: `${startTime}:00` }),
     };
 
     // Update the worklog


### PR DESCRIPTION
- Fix: Append :00 seconds to startTime for Tempo API v4 compatibility
  * Tempo API v4 requires time in HH:MM:SS format
  * Convert user input from HH:MM to HH:MM:SS in createWorklog, bulkCreateWorklogs, and editWorklog
  * Fixes 400 errors when creating/editing worklogs with startTime

- Feature: Display startTime in worklog retrieval output
  * Added startTime field to retrieveWorklogs output when available
  * Provides more detailed time tracking information

- Bump version to 1.2.2

Based on PR #13 by Filip Kalný (excluding strict time increment validation)