### PR TITLE
Fix: Convert issueId to number for Tempo API v4 compatibility

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -142,7 +142,7 @@ export async function createWorklog(
     const { id: issueId } = issue;
     // Prepare payload
     const payload = {
-      issueId,
+      issueId: Number(issueId),
       timeSpentSeconds: Math.round(timeSpentHours * 3600),
       startDate: date,
       authorAccountId: accountId,
@@ -231,7 +231,7 @@ export async function bulkCreateWorklogs(
 
         // Submit bulk request
         const response = await api.post(
-          `/worklogs/issue/${issueId}/bulk`,
+          `/worklogs/issue/${Number(issueId)}/bulk`,
           formattedEntries,
         );
         const createdWorklogs = response.data || [];


### PR DESCRIPTION
Fixes the 400 error that occurs when using `startTime` parameter with `createWorklog`.

  ## Problem
  Tempo API v4 requires `issueId` as an integer, not a string. When `startTime` is provided, the API performs stricter validation and rejects string IDs, resulting in a 400 error.

  ## Solution
  Convert `issueId` to number using `Number(issueId)` in:
  - `createWorklog` function
  - `bulkCreateWorklogs` function