### PR TITLE
feat: add OAuth 2.0 Bearer token support for Jira API

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,46 @@ The server requires the following environment variables:
 ```
 TEMPO_API_TOKEN     # Your Tempo API token
 JIRA_API_TOKEN      # Your Jira API token
-JIRA_EMAIL          # Your Jira account email
+JIRA_EMAIL          # Your Jira account email (required for basic auth)
 JIRA_BASE_URL       # Your Jira instance URL (e.g., https://your-org.atlassian.net)
+JIRA_AUTH_TYPE      # Optional: 'basic' (default) or 'bearer' for OAuth 2.0 tokens
 JIRA_TEMPO_ACCOUNT_CUSTOM_FIELD_ID     # Optional: Custom field ID for Tempo accounts
-
 ```
 
 You can set these in your environment or provide them in the MCP client configuration.
+
+### Authentication Types
+
+The server supports two authentication methods for the Jira API:
+
+#### Basic Authentication (default)
+
+Uses email and API token. This is the traditional method:
+
+```json
+{
+  "env": {
+    "JIRA_API_TOKEN": "your_api_token",
+    "JIRA_EMAIL": "your_email@example.com",
+    "JIRA_AUTH_TYPE": "basic"
+  }
+}
+```
+
+#### Bearer Token Authentication (OAuth 2.0)
+
+For users who want to use OAuth 2.0 scoped tokens for enhanced security:
+
+```json
+{
+  "env": {
+    "JIRA_API_TOKEN": "your_oauth_access_token",
+    "JIRA_AUTH_TYPE": "bearer"
+  }
+}
+```
+
+Note: When using `bearer` auth, `JIRA_EMAIL` is not required as the user is identified from the token.
 
 ## Tempo Account Configuration
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,7 @@ const config: Config = {
     baseUrl: env.JIRA_BASE_URL,
     token: env.JIRA_API_TOKEN,
     email: env.JIRA_EMAIL,
+    authType: env.JIRA_AUTH_TYPE,
     tempoAccountCustomFieldId:
       env.JIRA_TEMPO_ACCOUNT_CUSTOM_FIELD_ID || undefined,
   },


### PR DESCRIPTION
Add support for Bearer token authentication as an alternative to Basic Auth. This enables users to use OAuth 2.0 scoped tokens for enhanced security.

- Add JIRA_AUTH_TYPE env var ('basic' or 'bearer', default: basic)
- Update Jira API client to use Bearer auth when configured
- Use /myself endpoint for user lookup with Bearer auth
- Make JIRA_EMAIL optional when using Bearer auth
- Update README with authentication documentation

Closes #20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Jira bearer token auth option with `JIRA_AUTH_TYPE`, optional `JIRA_EMAIL`, and updates client/user lookup accordingly.
> 
> - **Auth & Jira Client**:
>   - Add dynamic auth header via `getAuthHeader()` to support `bearer` and default `basic` in `src/jira.ts`.
>   - Use `/rest/api/3/myself` for account lookup when `authType` is `bearer`; retain email-based search for `basic`.
> - **Config & Types**:
>   - Extend `envSchema` to include optional `JIRA_EMAIL`, new `JIRA_AUTH_TYPE` (`basic`|`bearer`, default `basic`), with refine rule requiring email for `basic`.
>   - Update `Config.jiraApi` to make `email` optional and add `authType`.
>   - Wire `authType` through `src/config.ts`.
> - **Docs**:
>   - Update `README.md` environment variables and add detailed sections for Basic vs Bearer authentication with examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cecfe39171eec421688c48d2238df024fb0ea687. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->