### PR TITLE
feat: add custom work attributes support for worklogs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,14 @@ server.tool(
 server.tool(
   'createWorklog',
   createWorklogSchema.shape,
-  async ({ issueKey, timeSpentHours, date, description, startTime }) => {
+  async ({
+    issueKey,
+    timeSpentHours,
+    date,
+    description,
+    startTime,
+    attributes,
+  }) => {
     try {
       const result = await tools.createWorklog(
         issueKey,
@@ -62,6 +69,7 @@ server.tool(
         date,
         description,
         startTime,
+        attributes,
       );
       return {
         content: result.content,
@@ -114,7 +122,14 @@ server.tool(
 server.tool(
   'editWorklog',
   editWorklogSchema.shape,
-  async ({ worklogId, timeSpentHours, description, date, startTime }) => {
+  async ({
+    worklogId,
+    timeSpentHours,
+    description,
+    date,
+    startTime,
+    attributes,
+  }) => {
     try {
       const result = await tools.editWorklog(
         worklogId,
@@ -122,6 +137,7 @@ server.tool(
         description || null,
         date || null,
         startTime || undefined,
+        attributes,
       );
       return {
         content: result.content,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import {
   ToolResponse,
   TempoWorklog,
+  WorkAttribute,
   WorklogResult,
   WorklogError,
   WorklogEntry,
@@ -93,10 +94,14 @@ export async function retrieveWorklogs(
       const timeSpentHours = (worklog.timeSpentSeconds / 3600).toFixed(2);
       const date = worklog.startDate || 'Unknown';
       const startTime = worklog.startTime || '';
+      const attributeValues = worklog.attributes?.values;
+      const attributesInfo = attributeValues?.length
+        ? ` | Attributes: ${JSON.stringify(attributeValues)}`
+        : '';
 
       return {
         type: 'text' as const,
-        text: `TempoWorklogId: ${tempoWorklogId} | IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date}${startTime ? ` | StartTime: ${startTime}` : ''} | Hours: ${timeSpentHours} | Description: ${description}`,
+        text: `TempoWorklogId: ${tempoWorklogId} | IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date}${startTime ? ` | StartTime: ${startTime}` : ''} | Hours: ${timeSpentHours} | Description: ${description}${attributesInfo}`,
       };
     });
 
@@ -131,6 +136,7 @@ export async function createWorklog(
   date: string,
   description: string = '',
   startTime: string | undefined = undefined,
+  attributes?: WorkAttribute[],
 ): Promise<ToolResponse> {
   try {
     // Get issue ID and account ID
@@ -140,6 +146,8 @@ export async function createWorklog(
     const account = await fetchTempoAccountFromIssue(issue);
 
     const { id: issueId } = issue;
+    // Prepare attributes array (auto-detected _Account_ takes precedence)
+    const attributesArray = mergeAttributes(account, attributes);
     // Prepare payload
     const payload = {
       issueId: Number(issueId),
@@ -148,9 +156,7 @@ export async function createWorklog(
       authorAccountId: accountId,
       description,
       ...(startTime && { startTime: `${startTime}:00` }),
-      ...(account && {
-        attributes: [{ key: '_Account_', value: account.key }],
-      }),
+      ...(attributesArray.length > 0 && { attributes: attributesArray }),
     };
 
     // Submit the worklog
@@ -164,12 +170,16 @@ export async function createWorklog(
     }
 
     const accountInfo = account ? ` with account '${account.name}'` : '';
+    const userAttrInfo =
+      attributes && attributes.length > 0
+        ? ` with attributes: ${attributes.map((a) => `${a.key}=${a.value}`).join(', ')}`
+        : '';
 
     return {
       content: [
         {
           type: 'text',
-          text: `Worklog with ID ${response.data.tempoWorklogId} created successfully for ${issueKey}${accountInfo}. Time logged: ${timeSpentHours} hours on ${date}${timeInfo}`,
+          text: `Worklog with ID ${response.data.tempoWorklogId} created successfully for ${issueKey}${accountInfo}${userAttrInfo}. Time logged: ${timeSpentHours} hours on ${date}${timeInfo}`,
         },
       ],
     };
@@ -216,16 +226,17 @@ export async function bulkCreateWorklogs(
         const account = await fetchTempoAccountFromIssue(issue);
 
         // Format entries for API
-        const formattedEntries = entries.map((entry) => ({
-          timeSpentSeconds: Math.round(entry.timeSpentHours * 3600),
-          startDate: entry.date,
-          authorAccountId,
-          description: entry.description || '',
-          ...(entry.startTime && { startTime: `${entry.startTime}:00` }),
-          ...(account && {
-            attributes: [{ key: '_Account_', value: account.key }],
-          }),
-        }));
+        const formattedEntries = entries.map((entry) => {
+          const attributesArray = mergeAttributes(account, entry.attributes);
+          return {
+            timeSpentSeconds: Math.round(entry.timeSpentHours * 3600),
+            startDate: entry.date,
+            authorAccountId,
+            description: entry.description || '',
+            ...(entry.startTime && { startTime: `${entry.startTime}:00` }),
+            ...(attributesArray.length > 0 && { attributes: attributesArray }),
+          };
+        });
 
         const { id: issueId } = issue;
 
@@ -351,6 +362,7 @@ export async function editWorklog(
   description: string | null = null,
   date: string | null = null,
   startTime: string | undefined = undefined,
+  attributes?: WorkAttribute[],
 ): Promise<ToolResponse> {
   try {
     // Get current worklog
@@ -365,6 +377,7 @@ export async function editWorklog(
       billableSeconds: Math.round(timeSpentHours * 3600),
       ...(description !== null && { description }),
       ...(startTime && { startTime: `${startTime}:00` }),
+      ...(attributes && attributes.length > 0 && { attributes }),
     };
 
     // Update the worklog
@@ -453,4 +466,31 @@ async function retrieveAccount(
 ): Promise<{ key: string; name: string }> {
   const response = await api.get(`/accounts/${id}`);
   return response.data;
+}
+
+/**
+ * Merge auto-detected account attribute with user-provided attributes.
+ * Auto-detected keys (_Account_) take precedence over user-provided duplicates.
+ */
+export function mergeAttributes(
+  account: { key: string; name: string } | undefined,
+  userAttributes?: WorkAttribute[],
+): WorkAttribute[] {
+  const attributesArray: WorkAttribute[] = [];
+  const autoKeys = new Set<string>();
+
+  if (account) {
+    attributesArray.push({ key: '_Account_', value: account.key });
+    autoKeys.add('_Account_');
+  }
+
+  if (userAttributes && userAttributes.length > 0) {
+    for (const attr of userAttributes) {
+      if (!autoKeys.has(attr.key)) {
+        attributesArray.push(attr);
+      }
+    }
+  }
+
+  return attributesArray;
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -369,6 +369,15 @@ export async function editWorklog(
     const response = await api.get<TempoWorklog>(`/worklogs/${worklogId}`);
     const worklog = response.data;
 
+    // Extract existing attributes from the worklog and merge with user-provided ones
+    const existingAttributes: WorkAttribute[] = (
+      worklog.attributes?.values || []
+    ).map((attr) => ({ key: attr.key, value: attr.value }));
+    const mergedAttributes = mergeExistingWithUserAttributes(
+      existingAttributes,
+      attributes,
+    );
+
     // Prepare update payload
     const updatePayload = {
       authorAccountId: worklog.author.accountId,
@@ -377,7 +386,7 @@ export async function editWorklog(
       billableSeconds: Math.round(timeSpentHours * 3600),
       ...(description !== null && { description }),
       ...(startTime && { startTime: `${startTime}:00` }),
-      ...(attributes && attributes.length > 0 && { attributes }),
+      ...(mergedAttributes.length > 0 && { attributes: mergedAttributes }),
     };
 
     // Update the worklog
@@ -493,4 +502,27 @@ export function mergeAttributes(
   }
 
   return attributesArray;
+}
+
+/**
+ * Merge existing worklog attributes with user-provided overrides.
+ * Existing attributes are preserved; user-provided attributes override matching keys.
+ */
+function mergeExistingWithUserAttributes(
+  existingAttributes: WorkAttribute[],
+  userAttributes?: WorkAttribute[],
+): WorkAttribute[] {
+  if (!userAttributes || userAttributes.length === 0) {
+    return existingAttributes;
+  }
+
+  const merged = new Map<string, string>();
+  for (const attr of existingAttributes) {
+    merged.set(attr.key, attr.value);
+  }
+  for (const attr of userAttributes) {
+    merged.set(attr.key, attr.value);
+  }
+
+  return Array.from(merged.entries()).map(([key, value]) => ({ key, value }));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,10 @@ export interface TempoWorklog {
   billableSeconds?: number;
   remainingEstimateSeconds?: number;
   startTime?: string;
-  attributes?: Array<any>;
+  attributes?: {
+    self?: string;
+    values: Array<{ key: string; value: string }>;
+  };
 }
 
 // MCP response interfaces

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,12 +33,20 @@ export const envSchema = z
 export type Env = z.infer<typeof envSchema>;
 
 // Worklog entry schema
+export const workAttributeSchema = z.object({
+  key: z.string().min(1, 'Attribute key cannot be empty'),
+  value: z.string().min(1, 'Attribute value cannot be empty'),
+});
+
+export type WorkAttribute = z.infer<typeof workAttributeSchema>;
+
 export const worklogEntrySchema = z.object({
   issueKey: issueKeySchema(),
   timeSpentHours: z.number().positive('Time spent must be positive'),
   date: dateSchema(),
   description: z.string().optional(),
   startTime: timeSchema().optional(),
+  attributes: z.array(workAttributeSchema).optional(),
 });
 
 export type WorklogEntry = z.infer<typeof worklogEntrySchema>;
@@ -55,6 +63,7 @@ export const createWorklogSchema = z.object({
   date: dateSchema(),
   description: z.string().optional().default(''),
   startTime: timeSchema().optional(),
+  attributes: z.array(workAttributeSchema).optional(),
 });
 
 export const bulkCreateWorklogsSchema = z.object({
@@ -69,6 +78,7 @@ export const editWorklogSchema = z.object({
   description: z.string().optional().nullable(),
   date: dateSchema().optional().nullable(),
   startTime: timeSchema().optional(),
+  attributes: z.array(workAttributeSchema).optional(),
 });
 
 export const deleteWorklogSchema = z.object({


### PR DESCRIPTION
## Summary

- Add optional `attributes` parameter to `createWorklog`, `bulkCreateWorklogs`, and `editWorklog` tools, allowing users to pass custom Tempo work attributes (e.g. `_WorkType_`, `_Category_`)
- User-provided attributes are merged with the auto-detected `_Account_` attribute; auto-detected keys take precedence to prevent duplicates
- Display work attributes conditionally in `retrieveWorklogs` output (only when present, matching the existing `startTime` pattern)

## Motivation

Many Tempo instances require mandatory work attributes like `_WorkType_` on worklogs. Without this change, worklogs created via MCP fail with `"Work attribute Work Type (_WorkType_) is required"`. This PR makes the MCP server usable for organizations with required custom work attributes.

## Changes

- **`src/types.ts`** — New `workAttributeSchema` + `WorkAttribute` type; added `attributes` to `createWorklogSchema`, `worklogEntrySchema`, and `editWorklogSchema`
- **`src/tools.ts`** — New `mergeAttributes()` helper for dedup-safe attribute merging; wired attributes through `createWorklog`, `bulkCreateWorklogs`, `editWorklog`; conditional attributes display in `retrieveWorklogs`
- **`src/index.ts`** — Pass `attributes` through `createWorklog` and `editWorklog` tool handlers

## Test plan

- [x] Verified `createWorklog` with `_WorkType_` attribute succeeds on live Tempo API
- [x] Verified `retrieveWorklogs` displays attributes when present, omits when absent
- [x] Build passes (`npm run build`)
- [x] Lint passes with 0 errors (`npm run lint`)
- [x] Format check passes (`npm run format:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)