### PR TITLE
Add OAuth 2.0 PKCE authentication for Jira API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Model Context Protocol (MCP) server for managing Tempo worklogs in Jira. This 
 - Node.js 18+ (LTS recommended)
 - Jira Cloud instance
 - Tempo API token
-- Jira API token
+- Jira API token (not required when using OAuth 2.0 PKCE authentication)
 
 ## Usage Options
 
@@ -135,11 +135,13 @@ You can run the server directly with Node by pointing to the built JavaScript fi
 The server requires the following environment variables:
 
 ```
-TEMPO_API_TOKEN     # Your Tempo API token
-JIRA_API_TOKEN      # Your Jira API token
-JIRA_EMAIL          # Your Jira account email (required for basic auth)
-JIRA_BASE_URL       # Your Jira instance URL (e.g., https://your-org.atlassian.net)
-JIRA_AUTH_TYPE      # Optional: 'basic' (default) or 'bearer' for OAuth 2.0 tokens
+TEMPO_API_TOKEN           # Your Tempo API token
+JIRA_API_TOKEN            # Your Jira API token (required for basic and bearer auth)
+JIRA_EMAIL                # Your Jira account email (required for basic auth)
+JIRA_BASE_URL             # Your Jira instance URL (e.g., https://your-org.atlassian.net)
+JIRA_AUTH_TYPE            # Optional: 'basic' (default), 'bearer', or 'oauth'
+JIRA_OAUTH_CLIENT_ID      # OAuth 2.0 client ID (required for oauth auth)
+JIRA_OAUTH_CLIENT_SECRET  # OAuth 2.0 client secret (required for oauth auth)
 JIRA_TEMPO_ACCOUNT_CUSTOM_FIELD_ID     # Optional: Custom field ID for Tempo accounts
 ```
 
@@ -147,7 +149,7 @@ You can set these in your environment or provide them in the MCP client configur
 
 ### Authentication Types
 
-The server supports two authentication methods for the Jira API:
+The server supports three authentication methods for the Jira API:
 
 #### Basic Authentication (default)
 
@@ -177,6 +179,29 @@ For users who want to use OAuth 2.0 scoped tokens for enhanced security:
 ```
 
 Note: When using `bearer` auth, `JIRA_EMAIL` is not required as the user is identified from the token.
+
+#### OAuth 2.0 PKCE Authentication
+
+Some Atlassian organizations restrict API token access via admin policy, which causes basic and bearer authentication to fail. The `oauth` type implements the full OAuth 2.0 authorization code flow with PKCE and works regardless of API token restrictions — tokens are short-lived and refreshed automatically without any manual management.
+
+On first use, a browser window opens for you to authorize access. Tokens are stored locally at `~/.tempo-mcp-server/tokens.json` and refreshed automatically.
+
+1. Create an OAuth 2.0 app in [Atlassian Developer Console](https://developer.atlassian.com/console/myapps/) with the `read:jira-user` and `read:jira-work` scopes and `http://localhost:7788/callback` as the callback URL.
+
+2. Configure the server:
+
+```json
+{
+  "env": {
+    "JIRA_BASE_URL": "https://your-org.atlassian.net",
+    "JIRA_AUTH_TYPE": "oauth",
+    "JIRA_OAUTH_CLIENT_ID": "your_client_id",
+    "JIRA_OAUTH_CLIENT_SECRET": "your_client_secret"
+  }
+}
+```
+
+Note: `JIRA_API_TOKEN` and `JIRA_EMAIL` are not required when using `oauth` auth.
 
 ## Tempo Account Configuration
 
@@ -261,6 +286,7 @@ tempo-mcp-server/
 │   ├── config.ts         # Configuration management
 │   ├── index.ts          # MCP server implementation
 │   ├── jira.ts           # Jira API integration
+│   ├── oauth.ts          # OAuth 2.0 PKCE flow and token management
 │   ├── tools.ts          # Tool implementations
 │   ├── types.ts          # TypeScript types and schemas
 │   └── utils.ts          # Utility functions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ivelin-web/tempo-mcp-server",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ivelin-web/tempo-mcp-server",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,8 @@ const config: Config = {
     token: env.JIRA_API_TOKEN,
     email: env.JIRA_EMAIL,
     authType: env.JIRA_AUTH_TYPE,
+    oauthClientId: env.JIRA_OAUTH_CLIENT_ID,
+    oauthClientSecret: env.JIRA_OAUTH_CLIENT_SECRET,
     tempoAccountCustomFieldId:
       env.JIRA_TEMPO_ACCOUNT_CUSTOM_FIELD_ID || undefined,
   },

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -1,6 +1,7 @@
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import { JiraUser, issueIdSchema, idOrKeySchema } from './types.js';
 import config from './config.js';
+import { getOAuthToken, OAuthConfig } from './oauth.js';
 
 // Build authorization header based on auth type
 function getAuthHeader(): string {
@@ -11,15 +12,43 @@ function getAuthHeader(): string {
   return `Basic ${Buffer.from(`${config.jiraApi.email}:${config.jiraApi.token}`).toString('base64')}`;
 }
 
-// Jira API client with authentication
-const jiraApi = axios.create({
-  baseURL: config.jiraApi.baseUrl,
-  headers: {
-    Authorization: getAuthHeader(),
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-  },
-});
+let _jiraApi: AxiosInstance | null = null;
+
+async function getJiraApi(): Promise<AxiosInstance> {
+  if (config.jiraApi.authType === 'oauth') {
+    const oauthCfg: OAuthConfig = {
+      clientId: config.jiraApi.oauthClientId!,
+      clientSecret: config.jiraApi.oauthClientSecret!,
+      siteUrl: config.jiraApi.baseUrl,
+    };
+    const { token, cloudId } = await getOAuthToken(oauthCfg);
+
+    if (!_jiraApi) {
+      _jiraApi = axios.create({
+        baseURL: `https://api.atlassian.com/ex/jira/${cloudId}`,
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+      });
+    }
+    _jiraApi.defaults.headers.common.Authorization = `Bearer ${token}`;
+    return _jiraApi;
+  }
+
+  // Jira API client with authentication
+  if (!_jiraApi) {
+    _jiraApi = axios.create({
+      baseURL: config.jiraApi.baseUrl,
+      headers: {
+        Authorization: getAuthHeader(),
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+  return _jiraApi;
+}
 
 // Standardized error handling for Jira API
 function formatJiraError(error: unknown, context: string): Error {
@@ -41,7 +70,11 @@ function formatJiraError(error: unknown, context: string): Error {
  */
 export async function getCurrentUserAccountId(): Promise<string> {
   try {
-    if (config.jiraApi.authType === 'bearer') {
+    const jiraApi = await getJiraApi();
+    if (
+      config.jiraApi.authType === 'bearer' ||
+      config.jiraApi.authType === 'oauth'
+    ) {
       // Bearer auth: get current user directly
       const response = await jiraApi.get<JiraUser>('/rest/api/3/myself');
       return response.data.accountId;
@@ -84,6 +117,7 @@ export async function getIssueKeyById(
       );
     }
 
+    const jiraApi = await getJiraApi();
     const response = await jiraApi.get(`/rest/api/3/issue/${issueId}`);
     return response.data.key;
   } catch (error) {
@@ -109,6 +143,7 @@ export async function getIssue(idOrKey: string | number): Promise<{
       );
     }
 
+    const jiraApi = await getJiraApi();
     const response = await jiraApi.get(`/rest/api/3/issue/${idOrKey}`);
 
     // Find the Tempo account key

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,0 +1,280 @@
+import { createServer } from 'http';
+import { createHash, randomBytes } from 'crypto';
+import { exec } from 'child_process';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import axios from 'axios';
+
+const ATLASSIAN_AUTH_URL = 'https://auth.atlassian.com/authorize';
+const ATLASSIAN_TOKEN_URL = 'https://auth.atlassian.com/oauth/token';
+const ATLASSIAN_RESOURCES_URL =
+  'https://api.atlassian.com/oauth/token/accessible-resources';
+
+export const OAUTH_CALLBACK_PORT = 7788;
+const REDIRECT_URI = `http://localhost:${OAUTH_CALLBACK_PORT}/callback`;
+
+const TOKEN_DIR = join(homedir(), '.tempo-mcp-server');
+const TOKEN_FILE = join(TOKEN_DIR, 'tokens.json');
+
+const SCOPES = 'read:jira-user read:jira-work offline_access';
+
+export interface OAuthConfig {
+  clientId: string;
+  clientSecret: string;
+  siteUrl: string;
+}
+
+interface StoredTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  cloudId: string;
+}
+
+// In-memory cache to avoid repeated disk reads within the same process
+let memCache: { token: string; cloudId: string; expiresAt: number } | null =
+  null;
+
+function loadStore(): Record<string, StoredTokens> {
+  try {
+    return JSON.parse(readFileSync(TOKEN_FILE, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveStore(store: Record<string, StoredTokens>): void {
+  mkdirSync(TOKEN_DIR, { recursive: true });
+  writeFileSync(TOKEN_FILE, JSON.stringify(store, null, 2), { mode: 0o600 });
+}
+
+function pkce(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+async function fetchCloudId(
+  accessToken: string,
+  siteUrl: string,
+): Promise<string> {
+  const res = await axios.get<Array<{ id: string; url: string; name: string }>>(
+    ATLASSIAN_RESOURCES_URL,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+
+  const normalize = (u: string) => u.replace(/\/$/, '').toLowerCase();
+  const match = res.data.find((r) => normalize(r.url) === normalize(siteUrl));
+
+  if (!match) {
+    const available = res.data.map((r) => r.url).join(', ');
+    throw new Error(
+      `Jira site "${siteUrl}" not found in accessible resources.\n` +
+        `Available sites: ${available}\n` +
+        `Set JIRA_BASE_URL to one of the available sites.`,
+    );
+  }
+
+  return match.id;
+}
+
+async function exchangeCode(
+  clientId: string,
+  clientSecret: string,
+  code: string,
+  verifier: string,
+): Promise<{ accessToken: string; refreshToken: string; expiresIn: number }> {
+  const res = await axios.post(ATLASSIAN_TOKEN_URL, {
+    grant_type: 'authorization_code',
+    client_id: clientId,
+    client_secret: clientSecret,
+    code,
+    redirect_uri: REDIRECT_URI,
+    code_verifier: verifier,
+  });
+  return {
+    accessToken: res.data.access_token,
+    refreshToken: res.data.refresh_token,
+    expiresIn: res.data.expires_in,
+  };
+}
+
+async function doRefresh(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+): Promise<{ accessToken: string; refreshToken: string; expiresIn: number }> {
+  const res = await axios.post(ATLASSIAN_TOKEN_URL, {
+    grant_type: 'refresh_token',
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+  });
+  return {
+    accessToken: res.data.access_token,
+    refreshToken: res.data.refresh_token ?? refreshToken,
+    expiresIn: res.data.expires_in,
+  };
+}
+
+async function authorize(
+  clientId: string,
+  clientSecret: string,
+  siteUrl: string,
+): Promise<StoredTokens> {
+  const { verifier, challenge } = pkce();
+  const state = randomBytes(16).toString('hex');
+
+  const authUrl = new URL(ATLASSIAN_AUTH_URL);
+  authUrl.searchParams.set('audience', 'api.atlassian.com');
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('scope', SCOPES);
+  authUrl.searchParams.set('redirect_uri', REDIRECT_URI);
+  authUrl.searchParams.set('state', state);
+  authUrl.searchParams.set('response_type', 'code');
+  authUrl.searchParams.set('prompt', 'consent');
+  authUrl.searchParams.set('code_challenge', challenge);
+  authUrl.searchParams.set('code_challenge_method', 'S256');
+
+  const code = await new Promise<string>((resolve, reject) => {
+    const server = createServer((req, res) => {
+      clearTimeout(timeout);
+      server.close(); // stop accepting new connections; current request completes normally
+
+      const url = new URL(req.url!, `http://localhost:${OAUTH_CALLBACK_PORT}`);
+      const error = url.searchParams.get('error');
+      const returnedCode = url.searchParams.get('code');
+      const returnedState = url.searchParams.get('state');
+
+      if (error || returnedState !== state || !returnedCode) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end('<h1>Authorization failed.</h1><p>You can close this tab.</p>');
+        reject(
+          new Error(error ? `OAuth error: ${error}` : 'Invalid OAuth callback'),
+        );
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(
+        '<h1>Authorization successful!</h1><p>You can close this tab.</p>',
+      );
+      resolve(returnedCode);
+    });
+
+    const timeout = setTimeout(
+      () => {
+        server.closeAllConnections?.();
+        server.close();
+        reject(new Error('OAuth timed out after 5 minutes'));
+      },
+      5 * 60 * 1000,
+    );
+
+    server.on('error', (err: NodeJS.ErrnoException) => {
+      clearTimeout(timeout);
+      if (err.code === 'EADDRINUSE') {
+        reject(
+          new Error(
+            `Port ${OAUTH_CALLBACK_PORT} is already in use. Stop the other process and try again.`,
+          ),
+        );
+      } else {
+        reject(err);
+      }
+    });
+
+    server.listen(OAUTH_CALLBACK_PORT, () => {
+      const url = authUrl.toString();
+      console.error('\n[Tempo MCP] Jira authorization required.');
+      console.error(
+        `[Tempo MCP] Opening browser... If it doesn't open, visit:\n\n  ${url}\n`,
+      );
+      const cmd =
+        process.platform === 'darwin'
+          ? `open "${url}"`
+          : process.platform === 'win32'
+            ? `start "" "${url}"`
+            : `xdg-open "${url}"`;
+      exec(cmd);
+    });
+  });
+
+  const { accessToken, refreshToken, expiresIn } = await exchangeCode(
+    clientId,
+    clientSecret,
+    code,
+    verifier,
+  );
+  const cloudId = await fetchCloudId(accessToken, siteUrl);
+  console.error('[Tempo MCP] Authorization successful!\n');
+
+  return {
+    accessToken,
+    refreshToken,
+    expiresAt: Date.now() + expiresIn * 1000,
+    cloudId,
+  };
+}
+
+export async function getOAuthToken(
+  cfg: OAuthConfig,
+): Promise<{ token: string; cloudId: string }> {
+  const BUFFER_MS = 5 * 60 * 1000;
+
+  // Check in-memory cache first
+  if (memCache && memCache.expiresAt > Date.now() + BUFFER_MS) {
+    return { token: memCache.token, cloudId: memCache.cloudId };
+  }
+
+  const store = loadStore();
+  const stored = store[cfg.siteUrl];
+
+  if (stored) {
+    if (stored.expiresAt > Date.now() + BUFFER_MS) {
+      memCache = {
+        token: stored.accessToken,
+        cloudId: stored.cloudId,
+        expiresAt: stored.expiresAt,
+      };
+      return { token: stored.accessToken, cloudId: stored.cloudId };
+    }
+
+    if (stored.refreshToken) {
+      try {
+        const { accessToken, refreshToken, expiresIn } = await doRefresh(
+          cfg.clientId,
+          cfg.clientSecret,
+          stored.refreshToken,
+        );
+        const updated: StoredTokens = {
+          accessToken,
+          refreshToken,
+          expiresAt: Date.now() + expiresIn * 1000,
+          cloudId: stored.cloudId,
+        };
+        store[cfg.siteUrl] = updated;
+        saveStore(store);
+        memCache = {
+          token: updated.accessToken,
+          cloudId: updated.cloudId,
+          expiresAt: updated.expiresAt,
+        };
+        return { token: updated.accessToken, cloudId: updated.cloudId };
+      } catch {
+        // Fall through to fresh authorization
+      }
+    }
+  }
+
+  const tokens = await authorize(cfg.clientId, cfg.clientSecret, cfg.siteUrl);
+  store[cfg.siteUrl] = tokens;
+  saveStore(store);
+  memCache = {
+    token: tokens.accessToken,
+    cloudId: tokens.cloudId,
+    expiresAt: tokens.expiresAt,
+  };
+  return { token: tokens.accessToken, cloudId: tokens.cloudId };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,14 +21,35 @@ export const envSchema = z
   .object({
     TEMPO_API_TOKEN: z.string().min(1, 'TEMPO_API_TOKEN is required'),
     JIRA_BASE_URL: z.string().min(1, 'JIRA_BASE_URL is required'),
-    JIRA_API_TOKEN: z.string().min(1, 'JIRA_API_TOKEN is required'),
+    JIRA_API_TOKEN: z.string().optional(),
     JIRA_EMAIL: z.string().optional(),
-    JIRA_AUTH_TYPE: z.enum(['basic', 'bearer']).optional().default('basic'),
+    JIRA_AUTH_TYPE: z
+      .enum(['basic', 'bearer', 'oauth'])
+      .optional()
+      .default('basic'),
+    JIRA_OAUTH_CLIENT_ID: z.string().optional(),
+    JIRA_OAUTH_CLIENT_SECRET: z.string().optional(),
     JIRA_TEMPO_ACCOUNT_CUSTOM_FIELD_ID: z.string().optional(),
   })
-  .refine((data) => data.JIRA_AUTH_TYPE === 'bearer' || data.JIRA_EMAIL, {
-    message: 'JIRA_EMAIL is required when using basic authentication',
-  });
+  .refine((data) => data.JIRA_AUTH_TYPE === 'oauth' || !!data.JIRA_API_TOKEN, {
+    message: 'JIRA_API_TOKEN is required for basic and bearer authentication',
+  })
+  .refine(
+    (data) =>
+      data.JIRA_AUTH_TYPE === 'bearer' ||
+      data.JIRA_AUTH_TYPE === 'oauth' ||
+      !!data.JIRA_EMAIL,
+    { message: 'JIRA_EMAIL is required when using basic authentication' },
+  )
+  .refine(
+    (data) =>
+      data.JIRA_AUTH_TYPE !== 'oauth' ||
+      (!!data.JIRA_OAUTH_CLIENT_ID && !!data.JIRA_OAUTH_CLIENT_SECRET),
+    {
+      message:
+        'JIRA_OAUTH_CLIENT_ID and JIRA_OAUTH_CLIENT_SECRET are required for OAuth authentication',
+    },
+  );
 
 export type Env = z.infer<typeof envSchema>;
 
@@ -130,14 +151,17 @@ export interface Config {
   tempoApi: { baseUrl: string; token: string };
   jiraApi: {
     baseUrl: string;
-    token: string;
+    token?: string;
     email?: string;
     /**
      * Authentication type for Jira API.
-     * - 'basic': Uses Basic Auth with email:token (default, requires JIRA_EMAIL)
-     * - 'bearer': Uses Bearer token auth (for OAuth 2.0 scoped tokens)
+     * - 'basic': Uses Basic Auth with email:token (default, requires JIRA_EMAIL + JIRA_API_TOKEN)
+     * - 'bearer': Uses Bearer token auth (requires JIRA_API_TOKEN)
+     * - 'oauth': Uses OAuth 2.0 with PKCE (requires JIRA_OAUTH_CLIENT_ID + JIRA_OAUTH_CLIENT_SECRET)
      */
-    authType: 'basic' | 'bearer';
+    authType: 'basic' | 'bearer' | 'oauth';
+    oauthClientId?: string;
+    oauthClientSecret?: string;
     /**
      * The id of the custom Jira field Id which links jira issues to Tempo accounts.
      * This must be set if your organization has configured a mandatory tempo custom work attribute of type "Account".


### PR DESCRIPTION
  ## Summary

  Some Atlassian organizations block API token access via admin policy, which prevents basic and bearer authentication from working. This adds a third authentication method — OAuth 2.0 with PKCE — that works regardless of API token restrictions.

  - Adds `src/oauth.ts` implementing the full OAuth 2.0 authorization code flow with PKCE: browser-based authorization, token
  storage at `~/.tempo-mcp-server/tokens.json`, and automatic token refresh
  - Adds `JIRA_AUTH_TYPE=oauth` option alongside existing `basic` and `bearer` types
  - Adds `JIRA_OAUTH_CLIENT_ID` and `JIRA_OAUTH_CLIENT_SECRET` env vars
  - Updates `jira.ts` to use a lazy async `getJiraApi()` so OAuth token fetching integrates with existing API calls
  - Documents setup steps including Atlassian Developer Console app registration