### PR TITLE
feat: add worklog analytics tools and harden auth/error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # Tempo API credentials
 # Get your token from Tempo > Settings > API Integration
+# Required scopes: "Worklogs" (View + Manage). Add "Schemes" (View) too if
+# you plan to use the getMissingWorklogDays tool — Tempo does not allow
+# editing scopes on an existing token, so create a new one with both scopes.
 TEMPO_API_TOKEN=your_tempo_api_token_here
 
 # Jira API credentials

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A Model Context Protocol (MCP) server for managing Tempo worklogs in Jira. This 
 - **Bulk Create**: Create multiple worklogs in a single operation
 - **Edit Worklog**: Modify time spent, dates, and descriptions
 - **Delete Worklog**: Remove existing worklogs
+- **Missing Days Report**: Find working days where you logged less than expected (uses Tempo's user-schedule, so holidays and non-working days are skipped automatically)
+- **Worklog Analytics**: Aggregate hours by issue, account, day, week, or month with totals and percentages
 
 ## System Requirements
 
@@ -124,11 +126,16 @@ You can run the server directly with Node by pointing to the built JavaScript fi
 1. **Tempo API Token**:
 
    - Go to Tempo > Settings > API Integration
-   - Create a new API token with appropriate permissions
+   - Create a new API token with **Custom access** and select at minimum:
+     - **Worklogs** (View + Manage) — for all worklog tools
+     - **Schemes** (View) — required for `getMissingWorklogDays` (reads the user-schedule)
+     - **Accounts** (View) — only if your worklogs use Tempo accounts
+   - Tempo does not allow editing scopes on an existing token; create a new one if you need to add scopes later.
 
 2. **Jira API Token**:
    - Go to [Atlassian API tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
-   - Create a new API token for your account
+   - Click **"Create API token"** (the classic, unscoped flow). This is what works with `basic` auth out of the box.
+   - **Do not use "Create API token with scopes"** — those tokens must be sent through Atlassian's gateway URL (`https://api.atlassian.com/ex/jira/{cloudId}/...`) with the cloud ID, which this server's `basic` auth path does not currently route to. They will fail with 401 against your site URL. If you only have a scoped token available (e.g. your org disabled classic tokens), use the [OAuth 2.0 PKCE flow](#oauth-20-pkce-authentication) instead — it routes through the gateway automatically.
 
 ## Environment Variables
 
@@ -276,6 +283,31 @@ Removes an existing worklog.
 ```
 Parameters:
 - worklogId: String
+```
+
+### getMissingWorklogDays
+
+Reports working days in a date range where the user has logged less time than expected. Expected hours per day come from the user's Tempo schedule, so holidays, non-working days, and part-time schedules are honoured automatically.
+
+```
+Parameters:
+- startDate: String (YYYY-MM-DD)
+- endDate: String (YYYY-MM-DD)
+- minHoursPerDay: Number (optional) — override the per-day threshold;
+                                      non-working days are still skipped
+```
+
+> **Required Tempo scope:** the `TEMPO_API_TOKEN` must include the **Schemes** scope (covers Workload Schemes, Holiday Schemes, User Schedule) in addition to **Worklogs**. Tempo does not allow modifying scopes on an existing token — if your current token only has Worklogs, create a new one at Tempo > Settings > API Integration.
+
+### getWorklogAnalytics
+
+Aggregates worklogs in a date range and returns hours, worklog count, and percentage per group, sorted by hours descending.
+
+```
+Parameters:
+- startDate: String (YYYY-MM-DD)
+- endDate: String (YYYY-MM-DD)
+- groupBy: "issue" | "account" | "day" | "week" | "month" (optional, default "issue")
 ```
 
 ## Project Structure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivelin-web/tempo-mcp-server",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "MCP server for managing Tempo worklogs in Jira",
   "main": "build/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import {
   bulkCreateWorklogsSchema,
   editWorklogSchema,
   deleteWorklogSchema,
+  getMissingWorklogDaysSchema,
+  getWorklogAnalyticsSchema,
 } from './types.js';
 
 // Create MCP server instance
@@ -32,6 +34,7 @@ server.tool(
       const result = await tools.retrieveWorklogs(startDate, endDate);
       return {
         content: result.content,
+        ...(result.isError && { isError: true }),
       };
     } catch (error) {
       console.error(
@@ -73,6 +76,7 @@ server.tool(
       );
       return {
         content: result.content,
+        ...(result.isError && { isError: true }),
       };
     } catch (error) {
       console.error(
@@ -100,6 +104,7 @@ server.tool(
       const result = await tools.bulkCreateWorklogs(worklogEntries);
       return {
         content: result.content,
+        ...(result.isError && { isError: true }),
       };
     } catch (error) {
       console.error(
@@ -141,6 +146,7 @@ server.tool(
       );
       return {
         content: result.content,
+        ...(result.isError && { isError: true }),
       };
     } catch (error) {
       console.error(
@@ -168,6 +174,7 @@ server.tool(
       const result = await tools.deleteWorklog(worklogId);
       return {
         content: result.content,
+        ...(result.isError && { isError: true }),
       };
     } catch (error) {
       console.error(
@@ -178,6 +185,76 @@ server.tool(
           {
             type: 'text',
             text: `Error deleting worklog: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+// Tool: getMissingWorklogDays - find working days with insufficient logged time
+server.tool(
+  'getMissingWorklogDays',
+  "Find working days in a date range where the user's logged time is below the expected hours from their Tempo user-schedule. Holidays and non-working days are skipped automatically. Returns days with their expected vs logged hours, plus a per-issue breakdown for partially-logged days. Requires the 'Schemes' scope on the Tempo API token (in addition to 'Worklogs').",
+  getMissingWorklogDaysSchema.shape,
+  async ({ startDate, endDate, minHoursPerDay }) => {
+    try {
+      const result = await tools.getMissingWorklogDays(
+        startDate,
+        endDate,
+        minHoursPerDay,
+      );
+      // Preserve isError so date-range / MAX_PAGES / 403 / etc. surface
+      // as proper MCP errors, not successful responses with error text.
+      return {
+        content: result.content,
+        ...(result.isError && { isError: true }),
+      };
+    } catch (error) {
+      console.error(
+        `[ERROR] getMissingWorklogDays failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error getting missing worklog days: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+// Tool: getWorklogAnalytics - aggregate worklogs by issue/account/day/week/month
+server.tool(
+  'getWorklogAnalytics',
+  "Aggregate worklogs in a date range and return hours, worklog count, and percentage per group, sorted by hours descending. groupBy options: 'issue' (default), 'account', 'day', 'week' (ISO 8601), 'month'. Note: 'account' grouping reads the _Account_ work attribute on each worklog — worklogs without an account attribute are bucketed as 'No account', so this grouping is only meaningful if your team uses Tempo accounts.",
+  getWorklogAnalyticsSchema.shape,
+  async ({ startDate, endDate, groupBy }) => {
+    try {
+      const result = await tools.getWorklogAnalytics(
+        startDate,
+        endDate,
+        groupBy,
+      );
+      // Preserve isError so date-range / MAX_PAGES / etc. surface as
+      // proper MCP errors, not successful responses with error text.
+      return {
+        content: result.content,
+        ...(result.isError && { isError: true }),
+      };
+    } catch (error) {
+      console.error(
+        `[ERROR] getWorklogAnalytics failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error getting worklog analytics: ${error instanceof Error ? error.message : String(error)}`,
           },
         ],
         isError: true,

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -65,51 +65,52 @@ function formatJiraError(error: unknown, context: string): Error {
 
 /**
  * Get user's account ID.
- * - For Bearer auth: uses /myself endpoint
- * - For Basic auth: searches by configured email
+ *
+ * Uses /myself for all auth types — it returns the authenticated user's own
+ * accountId regardless of basic / bearer / oauth, and avoids the email-based
+ * /user/search which can return empty results when email visibility is
+ * restricted by Atlassian privacy settings or scoped API token limits.
+ *
+ * Falls back to email search for basic auth if /myself fails, to preserve
+ * backwards compatibility with edge cases where /myself is unavailable.
  */
 export async function getCurrentUserAccountId(): Promise<string> {
+  const jiraApi = await getJiraApi();
+
   try {
-    const jiraApi = await getJiraApi();
-    if (
-      config.jiraApi.authType === 'bearer' ||
-      config.jiraApi.authType === 'oauth'
-    ) {
-      // Bearer auth: get current user directly
-      const response = await jiraApi.get<JiraUser>('/rest/api/3/myself');
-      return response.data.accountId;
+    const response = await jiraApi.get<JiraUser>('/rest/api/3/myself');
+    return response.data.accountId;
+  } catch (myselfError) {
+    // For basic auth, try the legacy email-search fallback
+    if (config.jiraApi.authType === 'basic' && config.jiraApi.email) {
+      try {
+        const response = await jiraApi.get<JiraUser[]>(
+          '/rest/api/3/user/search',
+          { params: { query: config.jiraApi.email } },
+        );
+        const users = response.data;
+        const user = users?.find(
+          (u) => u.emailAddress === config.jiraApi.email,
+        );
+        if (user) return user.accountId;
+        throw new Error(`No user found with email: ${config.jiraApi.email}`);
+      } catch (searchError) {
+        throw formatJiraError(searchError, 'Failed to get user account ID');
+      }
     }
-
-    // Basic auth: search by email
-    const response = await jiraApi.get<JiraUser[]>('/rest/api/3/user/search', {
-      params: { query: config.jiraApi.email },
-    });
-
-    const users = response.data;
-    if (!users || users.length === 0) {
-      throw new Error(`No user found with email: ${config.jiraApi.email}`);
-    }
-
-    // Find exact email match
-    const user = users.find((u) => u.emailAddress === config.jiraApi.email);
-    if (!user) {
-      throw new Error(`No exact match for email: ${config.jiraApi.email}`);
-    }
-
-    return user.accountId;
-  } catch (error) {
-    throw formatJiraError(error, 'Failed to get user account ID');
+    throw formatJiraError(myselfError, 'Failed to get user account ID');
   }
 }
 
 /**
- * Get Jira issue key from issue ID
+ * Get Jira issue key + summary by ID.
+ * Used by tools that need to render human-friendly issue labels like
+ * "PPSG-50 — [AI/Backend] Structural AI Generation of Localized".
  */
-export async function getIssueKeyById(
+export async function getIssueInfoById(
   issueId: string | number,
-): Promise<string> {
+): Promise<{ key: string; summary: string }> {
   try {
-    // Validate issue ID using the schema
     const result = issueIdSchema().safeParse(issueId);
     if (!result.success) {
       throw new Error(
@@ -119,9 +120,12 @@ export async function getIssueKeyById(
 
     const jiraApi = await getJiraApi();
     const response = await jiraApi.get(`/rest/api/3/issue/${issueId}`);
-    return response.data.key;
+    return {
+      key: response.data.key,
+      summary: response.data.fields?.summary || '',
+    };
   } catch (error) {
-    throw formatJiraError(error, `Failed to get issue key for ID ${issueId}`);
+    throw formatJiraError(error, `Failed to get issue info for ID ${issueId}`);
   }
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6,10 +6,21 @@ import {
   WorklogResult,
   WorklogError,
   WorklogEntry,
+  DaySchedule,
+  MissingWorklogDay,
+  AnalyticsGroup,
+  AnalyticsGroupBy,
 } from './types.js';
 import config from './config.js';
 import { getCurrentUserAccountId, getIssue } from './jira.js';
-import { formatError, getIssueKeysMap, calculateEndTime } from './utils.js';
+import {
+  formatError,
+  getIssueInfoMap,
+  extractWorklogIssueIds,
+  calculateEndTime,
+  formatHours,
+  formatPercent,
+} from './utils.js';
 
 // API client for Tempo
 const api = axios.create({
@@ -20,6 +31,67 @@ const api = axios.create({
   },
 });
 
+// Tempo's /worklogs endpoints accept up to limit=1000 per page (sibling
+// endpoints cap at 5000; 1000 is the documented safe practical cap). Asking
+// for 1000 means a typical month-long query fits in a single round trip.
+const TEMPO_PAGE_LIMIT = 1000;
+
+// Safety cap on total pages — protects against an infinite loop if Tempo's
+// `metadata.next` ever fails to terminate. At limit=1000 this is 500,000
+// worklogs / 100,000 schedule entries, well beyond any realistic query.
+// Hitting it throws (rather than silently truncating) so callers never get
+// misleadingly partial results.
+const MAX_PAGES = 500;
+
+/**
+ * Fetch all worklogs for the current user across paginated pages.
+ * Shared by retrieveWorklogs, getMissingWorklogDays, getWorklogAnalytics.
+ */
+async function fetchAllWorklogs(
+  startDate: string,
+  endDate: string,
+): Promise<{ worklogs: any[]; pagesProcessed: number }> {
+  const accountId = await getCurrentUserAccountId();
+
+  let allWorklogs: any[] = [];
+  let nextUrl: string | null = null;
+  let isFirstRequest = true;
+  let pageCount = 0;
+
+  do {
+    if (pageCount >= MAX_PAGES) {
+      throw new Error(
+        `Reached maximum page limit (${MAX_PAGES}) while fetching worklogs ` +
+          `for ${startDate}..${endDate}. Results would be incomplete — ` +
+          `narrow the date range and try again.`,
+      );
+    }
+
+    let response;
+    if (isFirstRequest) {
+      response = await api.get(`/worklogs/user/${accountId}`, {
+        params: { from: startDate, to: endDate, limit: TEMPO_PAGE_LIMIT },
+      });
+      isFirstRequest = false;
+    } else {
+      response = await axios.get(nextUrl!, {
+        headers: {
+          Authorization: `Bearer ${config.tempoApi.token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+    }
+
+    const pageWorklogs = response.data.results || [];
+    allWorklogs = allWorklogs.concat(pageWorklogs);
+
+    nextUrl = response.data.metadata?.next || null;
+    pageCount++;
+  } while (nextUrl);
+
+  return { worklogs: allWorklogs, pagesProcessed: pageCount };
+}
+
 /**
  * Retrieve worklogs for the configured user within a date range
  */
@@ -28,47 +100,10 @@ export async function retrieveWorklogs(
   endDate: string,
 ): Promise<ToolResponse> {
   try {
-    const accountId = await getCurrentUserAccountId();
-
-    // Fetch all pages of worklogs
-    let allWorklogs: any[] = [];
-    let nextUrl: string | null = null;
-    let isFirstRequest = true;
-    let pageCount = 0;
-    const MAX_PAGES = 500; // Safety limit to prevent infinite loops (25,000 worklogs max)
-
-    do {
-      if (pageCount >= MAX_PAGES) {
-        console.warn(
-          `Reached maximum page limit (${MAX_PAGES}) while fetching worklogs`,
-        );
-        break;
-      }
-
-      let response;
-      if (isFirstRequest) {
-        response = await api.get(`/worklogs/user/${accountId}`, {
-          params: { from: startDate, to: endDate },
-        });
-        isFirstRequest = false;
-      } else {
-        response = await axios.get(nextUrl!, {
-          headers: {
-            Authorization: `Bearer ${config.tempoApi.token}`,
-            'Content-Type': 'application/json',
-          },
-        });
-      }
-
-      const pageWorklogs = response.data.results || [];
-      allWorklogs = allWorklogs.concat(pageWorklogs);
-
-      // Check if there's a next page
-      nextUrl = response.data.metadata?.next || null;
-      pageCount++;
-    } while (nextUrl);
-
-    const worklogs = allWorklogs;
+    const { worklogs, pagesProcessed } = await fetchAllWorklogs(
+      startDate,
+      endDate,
+    );
 
     // If no worklogs found, return empty content
     if (worklogs.length === 0) {
@@ -83,13 +118,15 @@ export async function retrieveWorklogs(
     }
 
     // Get issue keys for all worklogs
-    const issueIdToKeyMap = await getIssueKeysMap(worklogs);
+    const issueInfoMap = await getIssueInfoMap(
+      extractWorklogIssueIds(worklogs),
+    );
 
     // Format the response
     const formattedContent = worklogs.map((worklog: any) => {
       const tempoWorklogId = worklog.tempoWorklogId || 'Unknown';
       const issueId = worklog.issue?.id || 'Unknown';
-      const issueKey = issueIdToKeyMap[issueId] || 'Unknown';
+      const issueKey = issueInfoMap[issueId]?.key || 'Unknown';
       const description = worklog.description || 'No description';
       const timeSpentHours = (worklog.timeSpentSeconds / 3600).toFixed(2);
       const date = worklog.startDate || 'Unknown';
@@ -109,7 +146,7 @@ export async function retrieveWorklogs(
       content: formattedContent,
       metadata: {
         totalCount: worklogs.length,
-        pagesProcessed: pageCount,
+        pagesProcessed,
         startDate,
         endDate,
       },
@@ -525,4 +562,420 @@ function mergeExistingWithUserAttributes(
   }
 
   return Array.from(merged.entries()).map(([key, value]) => ({ key, value }));
+}
+
+/**
+ * Fetch the user-schedule from Tempo for a date range.
+ * Returns daily expected hours, working/non-working/holiday classification.
+ * Handles both paginated wrapper and direct array responses.
+ *
+ * Requires the Tempo API token to include the "Schemes" scope (covers
+ * Workload Schemes, Holiday Schemes, User Schedule). 403 is rewritten to
+ * a clear scope-guidance message.
+ */
+async function fetchUserSchedule(
+  accountId: string,
+  startDate: string,
+  endDate: string,
+): Promise<DaySchedule[]> {
+  let allDays: DaySchedule[] = [];
+  let nextUrl: string | null = null;
+  let isFirstRequest = true;
+  let pageCount = 0;
+
+  try {
+    do {
+      if (pageCount >= MAX_PAGES) {
+        throw new Error(
+          `Reached maximum page limit (${MAX_PAGES}) while fetching user ` +
+            `schedule for ${startDate}..${endDate}. Results would be ` +
+            `incomplete — narrow the date range and try again.`,
+        );
+      }
+
+      let response;
+      if (isFirstRequest) {
+        response = await api.get(`/user-schedule/${accountId}`, {
+          params: { from: startDate, to: endDate, limit: TEMPO_PAGE_LIMIT },
+        });
+        isFirstRequest = false;
+      } else {
+        response = await axios.get(nextUrl!, {
+          headers: {
+            Authorization: `Bearer ${config.tempoApi.token}`,
+            'Content-Type': 'application/json',
+          },
+        });
+      }
+
+      const days: DaySchedule[] = Array.isArray(response.data)
+        ? response.data
+        : response.data.results || [];
+      allDays = allDays.concat(days);
+
+      nextUrl = Array.isArray(response.data)
+        ? null
+        : response.data.metadata?.next || null;
+      pageCount++;
+    } while (nextUrl);
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
+      throw new Error(
+        'Tempo API returned 403 for /user-schedule. Your TEMPO_API_TOKEN ' +
+          'is missing the "Schemes" scope (which covers Workload Schemes, ' +
+          'Holiday Schemes, and User Schedule). Tempo does not allow ' +
+          'modifying scopes on an existing token — create a new token at ' +
+          'Tempo > Settings > API Integration with both "Worklogs" and ' +
+          '"Schemes" scopes, then update TEMPO_API_TOKEN.',
+      );
+    }
+    throw error;
+  }
+
+  return allDays;
+}
+
+/**
+ * Reject inverted date ranges with a clear MCP error response.
+ * Returns null when the range is valid, or a ToolResponse to short-circuit.
+ * Lexicographic comparison is sound for YYYY-MM-DD strings.
+ */
+function validateDateRange(
+  startDate: string,
+  endDate: string,
+): ToolResponse | null {
+  if (startDate > endDate) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: `Invalid range: startDate (${startDate}) must be on or before endDate (${endDate}).`,
+        },
+      ],
+    };
+  }
+  return null;
+}
+
+/**
+ * Find working days in a range where the user has logged less time than
+ * Tempo expects (per user-schedule). Honours holidays / non-working days
+ * automatically. minHoursPerDay overrides the per-day expected hours but
+ * still skips non-working days.
+ */
+export async function getMissingWorklogDays(
+  startDate: string,
+  endDate: string,
+  minHoursPerDay?: number,
+): Promise<ToolResponse> {
+  const rangeError = validateDateRange(startDate, endDate);
+  if (rangeError) return rangeError;
+
+  try {
+    const accountId = await getCurrentUserAccountId();
+
+    const [schedule, { worklogs }] = await Promise.all([
+      fetchUserSchedule(accountId, startDate, endDate),
+      fetchAllWorklogs(startDate, endDate),
+    ]);
+
+    if (schedule.length === 0) {
+      // Empty schedule is a legitimate state — user has no workload scheme
+      // configured for this period. Not an error, just nothing to report.
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `No user-schedule entries returned by Tempo for ${startDate} to ${endDate}. The user may not have a workload scheme configured for this period.`,
+          },
+        ],
+        metadata: {
+          totalMissingDays: 0,
+          totalMissingHours: 0,
+          startDate,
+          endDate,
+        },
+      };
+    }
+
+    // Group worklogs by date, then by issue ID, summing seconds.
+    // Used to (a) compute total logged per day and (b) show per-day
+    // breakdown of what was actually logged on partially-missing days.
+    const loggedByDate = new Map<string, Map<string, number>>();
+    for (const w of worklogs) {
+      const date = w.startDate;
+      if (!date) continue;
+      const issueId = w.issue?.id ? String(w.issue.id) : 'unknown';
+      const issueMap = loggedByDate.get(date) ?? new Map<string, number>();
+      issueMap.set(
+        issueId,
+        (issueMap.get(issueId) ?? 0) + Number(w.timeSpentSeconds ?? 0),
+      );
+      loggedByDate.set(date, issueMap);
+    }
+
+    const overrideSeconds =
+      minHoursPerDay !== undefined ? Math.round(minHoursPerDay * 3600) : null;
+
+    const missing: MissingWorklogDay[] = [];
+    for (const day of schedule) {
+      // Skip days Tempo classifies as non-working, regardless of override
+      if (day.requiredSeconds <= 0) continue;
+
+      const requiredSeconds = overrideSeconds ?? day.requiredSeconds;
+      const dayIssues = loggedByDate.get(day.date);
+      const loggedSeconds = dayIssues
+        ? Array.from(dayIssues.values()).reduce((s, v) => s + v, 0)
+        : 0;
+      if (loggedSeconds >= requiredSeconds) continue;
+
+      const breakdown = dayIssues
+        ? Array.from(dayIssues.entries()).map(([issueId, seconds]) => ({
+            issueId,
+            hours: seconds / 3600,
+          }))
+        : [];
+
+      missing.push({
+        date: day.date,
+        type: day.type,
+        expectedHours: requiredSeconds / 3600,
+        loggedHours: loggedSeconds / 3600,
+        missingHours: (requiredSeconds - loggedSeconds) / 3600,
+        ...(day.holiday?.name ? { holiday: day.holiday.name } : {}),
+        ...(breakdown.length > 0 ? { loggedBreakdown: breakdown } : {}),
+      });
+    }
+
+    // Resolve issue keys + summaries for everything that appears in
+    // partial-day breakdowns (skipped if no partial days).
+    const partialIssueIds = new Set<string>();
+    for (const m of missing) {
+      for (const b of m.loggedBreakdown ?? []) {
+        if (b.issueId !== 'unknown') partialIssueIds.add(b.issueId);
+      }
+    }
+    const issueInfoMap =
+      partialIssueIds.size > 0
+        ? await getIssueInfoMap(Array.from(partialIssueIds))
+        : {};
+
+    if (missing.length === 0) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `All working days between ${startDate} and ${endDate} meet the expected hours.`,
+          },
+        ],
+        metadata: {
+          totalMissingDays: 0,
+          totalMissingHours: 0,
+          startDate,
+          endDate,
+        },
+      };
+    }
+
+    const totalMissingHours = missing.reduce(
+      (sum, d) => sum + d.missingHours,
+      0,
+    );
+
+    const dayWord = missing.length === 1 ? 'day' : 'days';
+    const lines: string[] = [
+      `Found ${missing.length} ${dayWord} with missing worklogs · ${startDate} to ${endDate}`,
+      `Total missing: ${formatHours(totalMissingHours)}`,
+      '',
+    ];
+    for (const d of missing) {
+      const typeBadge = d.type === 'WORKING_DAY' ? '' : ` [${d.type}]`;
+      const holidayBadge = d.holiday ? ` (${d.holiday})` : '';
+      lines.push(
+        `${d.date}${typeBadge}${holidayBadge} — missing ${formatHours(d.missingHours)} (${formatHours(d.loggedHours)} of ${formatHours(d.expectedHours)} logged)`,
+      );
+      for (const b of d.loggedBreakdown ?? []) {
+        const info = issueInfoMap[b.issueId];
+        const label = info
+          ? info.summary
+            ? `${info.key} — ${info.summary}`
+            : info.key
+          : b.issueId === 'unknown'
+            ? 'Unknown issue'
+            : `Issue ${b.issueId}`;
+        lines.push(`    ${label}: ${formatHours(b.hours)}`);
+      }
+    }
+
+    return {
+      content: [{ type: 'text', text: lines.join('\n') }],
+      metadata: {
+        totalMissingDays: missing.length,
+        totalMissingHours,
+        startDate,
+        endDate,
+        details: missing,
+      },
+    };
+  } catch (error) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: `Failed to get missing worklog days: ${formatError(error)}`,
+        },
+      ],
+    };
+  }
+}
+
+/**
+ * Aggregate worklogs in a date range by issue / account / day / week / month.
+ * Returns hours, count, and percentage per group, sorted by hours desc.
+ */
+export async function getWorklogAnalytics(
+  startDate: string,
+  endDate: string,
+  groupBy: AnalyticsGroupBy = 'issue',
+): Promise<ToolResponse> {
+  const rangeError = validateDateRange(startDate, endDate);
+  if (rangeError) return rangeError;
+
+  try {
+    const { worklogs } = await fetchAllWorklogs(startDate, endDate);
+
+    if (worklogs.length === 0) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `No worklogs found between ${startDate} and ${endDate}.`,
+          },
+        ],
+        metadata: {
+          totalHours: 0,
+          totalWorklogs: 0,
+          groupBy,
+          startDate,
+          endDate,
+        },
+      };
+    }
+
+    let issueInfoMap: Record<string, { key: string; summary: string }> = {};
+    if (groupBy === 'issue') {
+      issueInfoMap = await getIssueInfoMap(extractWorklogIssueIds(worklogs));
+    }
+
+    const buckets = new Map<string, { seconds: number; count: number }>();
+    for (const w of worklogs) {
+      const key = computeGroupKey(w, groupBy, issueInfoMap);
+      const bucket = buckets.get(key) ?? { seconds: 0, count: 0 };
+      bucket.seconds += Number(w.timeSpentSeconds ?? 0);
+      bucket.count += 1;
+      buckets.set(key, bucket);
+    }
+
+    const totalSeconds = Array.from(buckets.values()).reduce(
+      (s, b) => s + b.seconds,
+      0,
+    );
+    const totalHours = totalSeconds / 3600;
+
+    const groups: AnalyticsGroup[] = Array.from(buckets.entries())
+      .map(([key, b]) => ({
+        key,
+        hours: b.seconds / 3600,
+        worklogCount: b.count,
+        percentage: totalSeconds > 0 ? (b.seconds / totalSeconds) * 100 : 0,
+      }))
+      .sort((a, b) => b.hours - a.hours);
+
+    const worklogWord = worklogs.length === 1 ? 'worklog' : 'worklogs';
+    const groupWord = groups.length === 1 ? 'group' : 'groups';
+    const lines: string[] = [
+      `Worklog analytics · ${startDate} to ${endDate} · grouped by ${groupBy}`,
+      `Total: ${formatHours(totalHours)} across ${worklogs.length} ${worklogWord} in ${groups.length} ${groupWord}`,
+      '',
+    ];
+    for (const g of groups) {
+      const wlWord = g.worklogCount === 1 ? 'worklog' : 'worklogs';
+      const stats = `${formatHours(g.hours)} · ${formatPercent(g.percentage)} · ${g.worklogCount} ${wlWord}`;
+      if (groupBy === 'issue') {
+        // Two-line: key + summary on one, stats indented below
+        lines.push(g.key);
+        lines.push(`    ${stats}`);
+      } else {
+        // Single-line for date/account groups (no separate label)
+        lines.push(`${g.key} · ${stats}`);
+      }
+    }
+
+    return {
+      content: [{ type: 'text', text: lines.join('\n') }],
+      metadata: {
+        totalHours,
+        totalWorklogs: worklogs.length,
+        groupCount: groups.length,
+        groupBy,
+        startDate,
+        endDate,
+        details: groups,
+      },
+    };
+  } catch (error) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: `Failed to get worklog analytics: ${formatError(error)}`,
+        },
+      ],
+    };
+  }
+}
+
+function computeGroupKey(
+  worklog: any,
+  groupBy: AnalyticsGroupBy,
+  issueInfoMap: Record<string, { key: string; summary: string }>,
+): string {
+  switch (groupBy) {
+    case 'issue': {
+      const issueId = worklog.issue?.id;
+      if (!issueId) return 'Unknown issue';
+      const info = issueInfoMap[issueId];
+      if (!info) return `Issue ${issueId}`;
+      return info.summary ? `${info.key} — ${info.summary}` : info.key;
+    }
+    case 'account': {
+      const accountAttr = worklog.attributes?.values?.find(
+        (a: { key: string }) => a.key === '_Account_',
+      );
+      return accountAttr?.value || 'No account';
+    }
+    case 'day':
+      return worklog.startDate || 'Unknown date';
+    case 'week':
+      return worklog.startDate ? toIsoWeek(worklog.startDate) : 'Unknown week';
+    case 'month':
+      return worklog.startDate
+        ? worklog.startDate.slice(0, 7)
+        : 'Unknown month';
+  }
+}
+
+// ISO 8601 week date: YYYY-Www
+function toIsoWeek(dateStr: string): string {
+  const date = new Date(`${dateStr}T00:00:00Z`);
+  const dayNum = date.getUTCDay() || 7;
+  date.setUTCDate(date.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  const weekNum = Math.ceil(
+    ((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
+  );
+  return `${date.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,31 @@ export const deleteWorklogSchema = z.object({
   worklogId: z.string().min(1, 'Worklog ID is required'),
 });
 
+export const getMissingWorklogDaysSchema = z.object({
+  startDate: dateSchema(),
+  endDate: dateSchema(),
+  minHoursPerDay: z
+    .number()
+    .positive('minHoursPerDay must be positive')
+    .optional(),
+});
+
+export const analyticsGroupBySchema = z.enum([
+  'issue',
+  'account',
+  'day',
+  'week',
+  'month',
+]);
+
+export type AnalyticsGroupBy = z.infer<typeof analyticsGroupBySchema>;
+
+export const getWorklogAnalyticsSchema = z.object({
+  startDate: dateSchema(),
+  endDate: dateSchema(),
+  groupBy: analyticsGroupBySchema.optional().default('issue'),
+});
+
 // API interfaces
 export interface JiraUser {
   accountId: string;
@@ -158,6 +183,37 @@ export interface WorklogError {
   timeSpentHours: number;
   date: string;
   error: string;
+}
+
+// Tempo user-schedule API
+export type DayScheduleType =
+  | 'WORKING_DAY'
+  | 'NON_WORKING_DAY'
+  | 'HOLIDAY'
+  | 'HOLIDAY_AND_NON_WORKING_DAY';
+
+export interface DaySchedule {
+  date: string;
+  requiredSeconds: number;
+  type: DayScheduleType;
+  holiday?: { name?: string } | null;
+}
+
+export interface MissingWorklogDay {
+  date: string;
+  type: DayScheduleType;
+  expectedHours: number;
+  loggedHours: number;
+  missingHours: number;
+  holiday?: string;
+  loggedBreakdown?: { issueId: string; hours: number }[];
+}
+
+export interface AnalyticsGroup {
+  key: string;
+  hours: number;
+  worklogCount: number;
+  percentage: number;
 }
 
 export interface Config {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { getIssueKeyById } from './jira.js';
+import { getIssueInfoById } from './jira.js';
 
 /**
  * Standard error handling for API errors
@@ -13,39 +13,61 @@ export function formatError(error: unknown): string {
 }
 
 /**
- * Get issue keys for worklogs
- * Maps Jira issue IDs to their corresponding issue keys
+ * Extract unique Jira issue IDs from a list of worklogs.
  */
-export async function getIssueKeysMap(
-  worklogs: any[],
-): Promise<Record<string, string>> {
-  // Extract unique issue IDs
-  const uniqueIssueIds = [
+export function extractWorklogIssueIds(worklogs: any[]): string[] {
+  return [
     ...new Set(
-      worklogs.map((worklog) => worklog.issue?.id).filter((id) => id != null),
+      worklogs
+        .map((w) => w.issue?.id)
+        .filter((id) => id != null)
+        .map(String),
     ),
   ];
+}
 
-  if (uniqueIssueIds.length === 0) return {};
+/**
+ * Resolve Jira issue IDs to { key, summary } in parallel.
+ * Used by tools that group/display worklogs by issue. Failed lookups are
+ * silently dropped — callers fall back to "Issue {id}" / "Unknown issue"
+ * labels so a single deleted issue doesn't break the whole response.
+ */
+export async function getIssueInfoMap(
+  issueIds: (string | number)[],
+): Promise<Record<string, { key: string; summary: string }>> {
+  const unique = [...new Set(issueIds.map(String))];
+  if (unique.length === 0) return {};
 
-  // Create issue ID to key map
-  const issueIdToKeyMap: Record<string, string> = {};
-
-  // Fetch issue keys in parallel
+  const map: Record<string, { key: string; summary: string }> = {};
   await Promise.all(
-    uniqueIssueIds.map(async (issueId) => {
+    unique.map(async (issueId) => {
       try {
-        const issueKey = await getIssueKeyById(issueId);
-        issueIdToKeyMap[issueId] = issueKey;
+        map[issueId] = await getIssueInfoById(issueId);
       } catch (error) {
         console.error(
-          `Could not get key for issue ID ${issueId}: ${(error as Error).message}`,
+          `Could not get info for issue ID ${issueId}: ${(error as Error).message}`,
         );
       }
     }),
   );
 
-  return issueIdToKeyMap;
+  return map;
+}
+
+/**
+ * Format hours, dropping trailing zeros: 7.50 -> "7.5h", 30 -> "30h",
+ * 7.25 -> "7.25h". Caps precision at 2 decimals.
+ */
+export function formatHours(hours: number): string {
+  return `${parseFloat(hours.toFixed(2))}h`;
+}
+
+/**
+ * Format percentage similarly: 50.0 -> "50%", 25.5 -> "25.5%".
+ * Caps precision at 1 decimal.
+ */
+export function formatPercent(percent: number): string {
+  return `${parseFloat(percent.toFixed(1))}%`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds two new MCP tools for worklog insights, plus several bug fixes that surfaced while wiring them up.

### New tools
- **`getMissingWorklogDays`** — finds working days where logged time is below the user's expected schedule. Uses Tempo's user-schedule API so holidays, non-working days, and part-time schedules are honoured automatically. Per-issue breakdown for partially-logged days.
- **`getWorklogAnalytics`** — aggregates worklogs by `issue` / `account` / `day` / `week` (ISO 8601) / `month`. Returns hours, percentage, worklog count per group sorted by hours desc.

### Bug fixes (surfaced during integration)
- `getCurrentUserAccountId` now prefers `/rest/api/3/myself` for all auth types, with the email-search retained as a basic-auth fallback. Avoids empty results when Atlassian privacy or scoped-token restrictions hide email visibility.
- All 7 tool wrappers now propagate `isError` correctly. `bulkCreateWorklogs` was especially affected — full-batch failures were silently reported as successes because the wrapper was dropping its explicit `isError` flag.
- Pagination `MAX_PAGES` limit now throws instead of silent truncation. Returning incomplete data was worse than failing loudly.
- 403 from `/user-schedule` surfaces a clear scope-guidance message instead of an opaque axios error.

### Polish & optimisation
- `limit=1000` on Tempo paginated requests — typical month-long queries now fit in a single round trip.
- `formatHours` / `formatPercent` helpers drop trailing zeros (`7.5h`, `50%`).
- `validateDateRange` rejects `startDate > endDate` with a clear MCP error.
- Cleaner output: single text block per response, no leading dashes (which clashed visually with em-dashes in issue titles), two-line layout for issue grouping.
- Consolidated `getIssueInfoMap` helper (resolves key + summary in one pass); removed dead `getIssueKeysMap` / `getIssueKeyById`.

### Docs
- README clarifies classic vs scoped Jira API tokens and the OAuth fallback for orgs that disable classic tokens.
- `.env.example` notes the Schemes scope requirement for Tempo.
- Tool descriptions added in `index.ts` including the `account` groupBy caveat.

Bumps to **1.6.0**.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` clean
- [x] `getMissingWorklogDays` tested against live Tempo: zero-logged days, partially-logged days with breakdown, full week with no missing
- [x] `getWorklogAnalytics` tested with `groupBy: issue` (returns key + Jira summary, percentages sum to 100%)
- [x] 403 scope error verified — gives clear guidance message
- [x] Empty schedule case — returns informative message, not error
- [ ] OAuth and bearer auth paths not tested in this PR (changed via /myself preference; existing logic preserved)
- [ ] Inverted date range (`startDate > endDate`) verified to short-circuit with the new guard
- [ ] `bulkCreateWorklogs` full-batch failure — verify `isError` now reaches the MCP client (existing behaviour was silently `success`)

## Notes for reviewers
- The "Create API token with scopes" Atlassian flow does **not** work with this server's basic auth path (scoped tokens require the `api.atlassian.com/ex/jira/{cloudId}` gateway). README now calls this out and points to OAuth as the workaround. A follow-up PR could add native scoped-token support via a `JIRA_CLOUD_ID` env var.
- The `account` groupBy in `getWorklogAnalytics` only makes sense if your team uses Tempo accounts (`_Account_` work attribute on worklogs). Documented in the tool description.