### PR TITLE
feat: add remote MCP server on Cloudflare Workers

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,9 @@
+# Local dev secrets for `wrangler dev`. Copy to `.dev.vars` (gitignored).
+#
+# ENCRYPTION_KEY: 32+ random bytes, base64 or hex. Used to AES-GCM-encrypt
+# per-user Tempo+Jira credentials in Workers KV.
+# Generate with: openssl rand -base64 48
+ENCRYPTION_KEY=replace_with_openssl_rand_base64_48_output
+
+# Optional: pin a specific app origin for CORS. Defaults to "*" if unset.
+# ALLOWED_ORIGIN=https://claude.ai

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,9 @@ coverage/
 # Misc
 .tmp/
 temp/
-.cache/ 
+.cache/
 .eslintcache
+
+# Cloudflare Workers
+.wrangler/
+.dev.vars

--- a/README.md
+++ b/README.md
@@ -19,19 +19,134 @@ A Model Context Protocol (MCP) server for managing Tempo worklogs in Jira. This 
 
 ## System Requirements
 
-- Node.js 18+ (LTS recommended)
+- Node.js 18+ (LTS recommended) — only needed for the local stdio modes
 - Jira Cloud instance
 - Tempo API token
 - Jira API token (not required when using OAuth 2.0 PKCE authentication)
 
 ## Usage Options
 
-There are two main ways to use this MCP server:
+There are three ways to use this MCP server:
 
-1. **NPX (Recommended for most users)**: Run directly without installation
-2. **Local Clone**: Clone the repository for development or customization
+1. **Remote / Cloudflare Workers (no install)** — host once, share with your team. Each user generates their own URL via a setup page and pastes it into Claude.ai or ChatGPT. Works from web and mobile.
+2. **NPX**: Run directly with `npx` on your laptop, no clone required.
+3. **Local Clone**: Clone the repository for development or customization.
 
-## Option 1: NPX Usage
+If you just want to use the server, option 1 is the easiest and works on phones too. If you're a maintainer deploying for your team, see the [Remote deployment guide](#remote-deployment-cloudflare-workers).
+
+## Option 1: Remote (Cloudflare Workers)
+
+### For end users
+
+Once your team has the server deployed, the flow is:
+
+1. Open `https://<your-deployment>.workers.dev/setup`.
+2. Paste your Tempo API token, Jira base URL, Jira API token, and Jira email. Hit **Generate MCP URL**.
+3. The page returns a personal URL like `https://<your-deployment>.workers.dev/mcp/u_<random>`. Copy it.
+4. In **Claude.ai → Settings → Connectors → Add custom connector**, paste the URL.
+5. The connector syncs across web, desktop, and mobile (iOS/Android).
+
+For ChatGPT: enable Settings → Apps → Advanced → **Developer mode** (Pro/Plus/Business+), then add the URL as a custom MCP server. Plus/Pro accounts can read; write tools (create/edit worklogs) require Business+ per OpenAI's tier.
+
+The URL contains your credentials — treat it like a password, don't share or commit it.
+
+### Remote deployment (Cloudflare Workers)
+
+Free-tier hosting on Cloudflare Workers. ~5–10 minutes from clone to live URL. Anyone can fork and self-host — no upstream coordination needed.
+
+#### Prerequisites
+
+- A Cloudflare account (free plan is enough).
+- Node.js 18+ and `npm` locally — only used for `wrangler` CLI; the Worker runtime itself doesn't run Node.
+
+#### One-time setup
+
+```bash
+git clone https://github.com/ivelin-web/tempo-mcp-server.git
+cd tempo-mcp-server
+npm install
+
+# 1. Log in to Cloudflare (opens browser).
+npx wrangler login
+
+# 2. Create your own KV namespace for per-user credentials.
+npx wrangler kv namespace create USERS
+```
+
+> ⚠️ **Important:** copy the `id` returned by step 2 and paste it into [`wrangler.jsonc`](wrangler.jsonc) → `kv_namespaces[0].id`. The committed value is intentionally empty — `wrangler deploy` will fail with `KV namespace … is not valid` until you fill it in. KV namespace ids are per-account and aren't sensitive, but each fork needs its own.
+>
+> If you want to keep your local id out of `git diff` after editing, run once: `git update-index --skip-worktree wrangler.jsonc`. Reverse with `--no-skip-worktree` when you need to commit other config changes.
+
+```bash
+# 3. Generate and store the encryption key.
+#    Used to AES-GCM-encrypt per-user credentials in KV.
+openssl rand -base64 48 | npx wrangler secret put ENCRYPTION_KEY
+
+# 4. (Optional) Pin the CORS origin. Defaults to "*". Set it if you only
+#    want browsers from a specific app to call the Worker.
+echo "https://claude.ai" | npx wrangler secret put ALLOWED_ORIGIN
+
+# 5. Deploy.
+npm run remote:deploy
+# → outputs https://tempo-mcp-server.<your-account>.workers.dev
+```
+
+Visit `/setup` on the deployed URL to onboard your first user.
+
+#### Updating an existing deployment
+
+After pulling new commits from upstream:
+
+```bash
+npm install              # picks up any new deps
+npm run remote:deploy    # ships the new Worker bundle
+```
+
+Secrets and KV data persist across deploys. `compatibility_date` and `compatibility_flags` in `wrangler.jsonc` are pinned, so behaviour doesn't drift silently when Cloudflare ships runtime changes.
+
+#### Local development
+
+```bash
+cp .dev.vars.example .dev.vars
+# edit .dev.vars and put a real ENCRYPTION_KEY (any value works locally)
+npm run remote:dev
+# → http://localhost:8787 with a mock KV; data is wiped between sessions
+```
+
+Other useful scripts:
+
+- `npm run remote:typecheck` — type-check the Worker bundle (uses `tsconfig.worker.json`).
+- `npm run remote:tail` — stream live logs from the deployed Worker.
+
+#### Troubleshooting
+
+- **`KV namespace … is not valid`** — `kv_namespaces[0].id` in `wrangler.jsonc` is empty (or wrong). Run `npx wrangler kv namespace create USERS` and paste the new id.
+- **`ENCRYPTION_KEY is not defined`** at runtime — secret wasn't set. Re-run step 3.
+- **`Rate limit binding … not available`** — your account's plan doesn't include the Workers Rate Limiting API. Either upgrade, or remove the `ratelimits` block in `wrangler.jsonc` and the `SETUP_RATE_LIMITER.limit(...)` call in `src/remote/worker.ts`.
+- **404 from `/mcp/u_…`** — the user id is unknown (or never existed). The Worker returns 404 by design for invalid/missing ids; have the user re-run `/setup`.
+- **Existing users suddenly can't connect** — most likely cause is a rotated `ENCRYPTION_KEY`; existing AES-GCM blobs can't be decrypted with the new key. See the warning below.
+
+#### How it works
+
+**Credential storage:** the `/setup` POST handler AES-GCM encrypts the form data with `ENCRYPTION_KEY` and stores it in KV under `user:u_<random>`. Each MCP request reads + decrypts that record, builds an `McpServer` for that single request, and dispatches via Cloudflare's official `createMcpHandler`. No credentials are held in memory between requests; no Durable Objects are used.
+
+> **Treat `ENCRYPTION_KEY` as long-lived.** Rotating it invalidates every existing user record (the AES-GCM tag won't validate against the new key), and all your users will need to re-run `/setup`. Pick a key from `openssl rand -base64 48` once and never change it.
+
+**Auth model:** the URL `/mcp/u_<id>` _is_ the credential. The 22-char base64url id carries ~128 bits of entropy. We never return 401 for that path (Claude.ai web has known bugs around the 401-then-OAuth flow), and we return 404 for unknown ids. This matches the URL-token pattern used by Zapier MCP, Pipedream MCP, and similar.
+
+**Hardening already in place:**
+
+- Per-IP rate limit (5 req/min) on `POST /setup`, via Cloudflare's native Rate Limiting binding.
+- `Cache-Control: no-store` on `/setup` responses so the success page (which contains the MCP URL) and the error re-render (which echoes tokens back) never sit in any cache.
+- `Referrer-Policy: no-referrer` on every HTML page so the MCP URL doesn't leak via referrer headers.
+
+**Limits to know about:**
+
+- Workers free plan: 100k requests/day, 50ms CPU per request (we are I/O-bound, comfortable).
+- KV free plan: 100k reads/day, 1k writes/day. Setup writes once per user; reads happen per MCP call.
+- The Worker only supports Jira **basic** auth (classic API token + email). Bearer and the OAuth 2.0 PKCE flow are stdio-only — bearer requires gateway URL routing that the Worker does not yet do, and PKCE needs a browser callback the Worker can't host.
+
+## Option 2: NPX Usage
 
 The easiest way to use this server is via npx without installation:
 
@@ -67,7 +182,7 @@ The easiest way to use this server is via npx without installation:
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=Jira%20Tempo&config=eyJjb21tYW5kIjoibnB4IC15IEBpdmVsaW4td2ViL3RlbXBvLW1jcC1zZXJ2ZXIiLCJlbnYiOnsiVEVNUE9fQVBJX1RPS0VOIjoieW91cl90ZW1wb19hcGlfdG9rZW5faGVyZSIsIkpJUkFfQVBJX1RPS0VOIjoieW91cl9qaXJhX2FwaV90b2tlbl9oZXJlIiwiSklSQV9FTUFJTCI6InlvdXJfZW1haWxAZXhhbXBsZS5jb20iLCJKSVJBX0JBU0VfVVJMIjoiaHR0cHM6Ly95b3VyLW9yZy5hdGxhc3NpYW4ubmV0In19)
 
-## Option 2: Local Repository Clone
+## Option 3: Local Repository Clone
 
 ### Installation
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,7 +16,7 @@ const weDontMindSlowerRulesAsTheyAreUsuallyTheBestBecauseTheyUseTypeInformation 
 export default tseslint.config(
   // Ignore some directories
   {
-    ignores: ['node_modules', 'dist', 'build', 'coverage'],
+    ignores: ['node_modules', 'dist', 'build', 'coverage', '.wrangler'],
   },
   // Some additional eslint configuration options
   {
@@ -29,6 +29,27 @@ export default tseslint.config(
           // allows configuration files (such as this file) to be linted even if it's not listed in the tsconfig.json
           allowDefaultProject: ['*.mjs', '*.js'],
         },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    files: ['src/**/*.ts'],
+    ignores: ['src/remote/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: './tsconfig.node.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    files: ['src/remote/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: './tsconfig.worker.json',
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,24 @@
 {
   "name": "@ivelin-web/tempo-mcp-server",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ivelin-web/tempo-mcp-server",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.6.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "agents": "^0.11.9",
         "axios": "^1.6.7",
-        "zod": "^3.24.2"
+        "zod": "^4.3.6"
       },
       "bin": {
         "tempo-mcp-server": "build/index.js"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260426.1",
         "@eslint/js": "^9.28.0",
         "@types/node": "^20.11.0",
         "eslint": "^9.28.0",
@@ -27,16 +29,645 @@
         "prettier": "3.5.3",
         "tsx": "^4.7.0",
         "typescript": "^5.8.3",
-        "typescript-eslint": "^8.34.0"
+        "typescript-eslint": "^8.34.0",
+        "wrangler": "^4.86.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.105",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.105.tgz",
+      "integrity": "sha512-XpERadvLMHkYGJO4hz1Sw7Y9J705Iex48TmdZLdZdaPiFFtVgiA9qhXugLUWGAxdlXU/2N6ipoPSOwfnULZbXw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.9",
+        "@ai-sdk/provider-utils": "4.0.24",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.9.tgz",
+      "integrity": "sha512-/ngMKqKdL9dSlY/eQ3NFDzzFyw0Hix+cbFFlyuKEKcOgpHdBt/spKUvX/i0wGrDLFPYJeVvv3N0j92LxWRL7yQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.24.tgz",
+      "integrity": "sha512-oXIw1oLmuBILuvHgSj6w5LOV8oSnFRouPSv0MGkG9sRMeukZ9JnMF17kldaRQaRq8lSJIxo6aS3NzWlVmSb+4Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.9",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.28.6",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.0.tgz",
+      "integrity": "sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-syntax-decorators": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.28.6.tgz",
+      "integrity": "sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260426.1.tgz",
+      "integrity": "sha512-Ch7DqsmYzSQRTY87pZpsGsFVz9VVBnLPnCBOHxKt1HH25a7oMu1w1PbPWqVmE0VerCLsj/TScX7Ob3v6E14TZw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260426.1.tgz",
+      "integrity": "sha512-0m0U8vaPRH25SpKjbSyRql6gmPe4rCsETRV2WW0qBnuMdKNr5Vh5/Uez80xVrfiCCRMTULGeg63Nqg2vg6CDOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260426.1.tgz",
+      "integrity": "sha512-C8LlC8uSYzg49y51n++75esxZmMp+Uz1OKHHA/4lkv6rjOTbcHQJuEwSLppjybVIXpv7A8MBhbu9iyCTvyv1mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260426.1.tgz",
+      "integrity": "sha512-ESVp/OIFMAqjQsa8BOP2BQQz5Vpfv6ncN6lNnIuNeOgsISQBdYk+LA60bwQHMud9tvmnSYtONp1zkZ8OQz+x6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260426.1.tgz",
+      "integrity": "sha512-d3Xj/IjINRgNVwH+eKhpUn4xkkcEewbWXbOvBlapiirKWh5zl9m0Epi3qOqmjyRYK6MICqIGXg4qZBEt0lxudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260426.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260426.1.tgz",
+      "integrity": "sha512-cBYeQaWwv/jFV8ualmwp6wIxmAf0rDe2DPPQwPbslKmPHqgv861YpAvm45r05K40QboZgxNQVIPgNkmtHqZeJQ=="
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
-      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
       "cpu": [
         "ppc64"
       ],
@@ -50,9 +681,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
-      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
       "cpu": [
         "arm"
       ],
@@ -66,9 +697,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
-      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
       "cpu": [
         "arm64"
       ],
@@ -82,9 +713,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
-      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
       "cpu": [
         "x64"
       ],
@@ -114,9 +745,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
-      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
       "cpu": [
         "x64"
       ],
@@ -130,9 +761,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
-      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +777,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
-      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
       "cpu": [
         "x64"
       ],
@@ -162,9 +793,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
-      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
       "cpu": [
         "arm"
       ],
@@ -178,9 +809,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
-      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
       "cpu": [
         "arm64"
       ],
@@ -194,9 +825,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
-      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
       "cpu": [
         "ia32"
       ],
@@ -210,9 +841,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
-      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
       "cpu": [
         "loong64"
       ],
@@ -226,9 +857,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
-      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
       "cpu": [
         "mips64el"
       ],
@@ -242,9 +873,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
-      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
       "cpu": [
         "ppc64"
       ],
@@ -258,9 +889,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
-      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
       "cpu": [
         "riscv64"
       ],
@@ -274,9 +905,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
-      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
       "cpu": [
         "s390x"
       ],
@@ -290,9 +921,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
-      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
       "cpu": [
         "x64"
       ],
@@ -306,9 +937,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
-      "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
       "cpu": [
         "arm64"
       ],
@@ -322,9 +953,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
-      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
       "cpu": [
         "x64"
       ],
@@ -338,9 +969,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
-      "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
       "cpu": [
         "arm64"
       ],
@@ -354,9 +985,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
-      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
       "cpu": [
         "x64"
       ],
@@ -369,10 +1000,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
-      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
       "cpu": [
         "x64"
       ],
@@ -386,9 +1033,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
-      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
       "cpu": [
         "arm64"
       ],
@@ -402,9 +1049,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
-      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
       "cpu": [
         "ia32"
       ],
@@ -418,9 +1065,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
-      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
       "cpu": [
         "x64"
       ],
@@ -555,9 +1202,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -577,9 +1224,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -588,11 +1235,26 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
@@ -623,6 +1285,15 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -649,23 +1320,615 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.6.1.tgz",
-      "integrity": "sha512-oxzMzYCkZHMntzuyerehK3fV6A2Kwh5BD6CGEJSVDU2QNEhfLOptf2X7esQgaHZXHZY0oHmMsOtIDLP71UJXgA==",
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
       "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "pkce-challenge": "^4.1.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -703,6 +1966,364 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -717,7 +2338,6 @@
     },
     "node_modules/@types/node": {
       "version": "20.17.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
       "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
       "dev": true,
       "dependencies": {
@@ -905,21 +2525,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -968,10 +2588,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -981,9 +2612,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1001,10 +2632,123 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agents": {
+      "version": "0.11.9",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.11.9.tgz",
+      "integrity": "sha512-La8kXl/zEr9tu17Xc5BXb5Xz5yfrH+Oh98nnWtj1OxteO1AB0i2R26w77pXCT0ffViLaE3RtgN2dOq8QGDTwsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-proposal-decorators": "^7.29.0",
+        "@cfworker/json-schema": "^4.1.1",
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "@rolldown/plugin-babel": "^0.2.3",
+        "cron-schedule": "^6.0.0",
+        "mimetext": "^3.0.28",
+        "nanoid": "^5.1.9",
+        "partyserver": "^0.5.5",
+        "partysocket": "1.1.18",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "agents": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@cloudflare/ai-chat": ">=0.5.2 <1.0.0",
+        "@cloudflare/codemode": ">=0.3.4 <1.0.0",
+        "@tanstack/ai": ">=0.10.2 <1.0.0",
+        "@x402/core": "^2.0.0",
+        "@x402/evm": "^2.0.0",
+        "ai": "^6.0.0",
+        "react": "^19.0.0",
+        "vite": ">=6.0.0 <9.0.0",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/ai-chat": {
+          "optional": true
+        },
+        "@cloudflare/codemode": {
+          "optional": true
+        },
+        "@tanstack/ai": {
+          "optional": true
+        },
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/evm": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agents/node_modules/@rolldown/plugin-babel": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/plugin-babel/-/plugin-babel-0.2.3.tgz",
+      "integrity": "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=22.12.0 || ^24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.29.0 || ^8.0.0-rc.1",
+        "@babel/plugin-transform-runtime": "^7.29.0 || ^8.0.0-rc.1",
+        "@babel/runtime": "^7.27.0 || ^8.0.0-rc.1",
+        "rolldown": "^1.0.0-rc.5",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/plugin-transform-runtime": {
+          "optional": true
+        },
+        "@babel/runtime": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agents/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.169",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.169.tgz",
+      "integrity": "sha512-eDAIc8bJJ3Ktk5qvBvWfAK7Uwj6zrOMI9VvQ6yLfF+7HdqnR0TSxgkLuIONrmowB2OujeAuVF9jalpNPJSN57g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.105",
+        "@ai-sdk/provider": "3.0.9",
+        "@ai-sdk/provider-utils": "4.0.24",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1017,10 +2761,49 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ansi-escapes": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "dev": true,
       "dependencies": {
         "environment": "^1.0.0"
@@ -1033,10 +2816,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "engines": {
         "node": ">=12"
       },
@@ -1072,7 +2854,6 @@
     },
     "node_modules/axios": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
       "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -1086,64 +2867,53 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true
+    },
     "node_modules/body-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.1.0.tgz",
-      "integrity": "sha512-/hPxh61E+ll0Ujp24Ilm64cykicul1ypfwjVttduAiEdtnJFvLePSrIPk+HMImtNv5270wOGCb1Tns2rybMkoQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.5.2",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1160,6 +2930,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/bytes": {
@@ -1186,6 +2990,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -1205,6 +3010,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1251,6 +3077,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/color-convert": {
@@ -1304,28 +3144,39 @@
       "dev": true
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1334,8 +3185,20 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/cors": {
@@ -1350,11 +3213,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cron-schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-6.0.0.tgz",
+      "integrity": "sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1365,11 +3236,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1402,13 +3274,13 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -1427,18 +3299,26 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-      "dev": true
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1453,6 +3333,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-define-property": {
@@ -1536,10 +3425,404 @@
         "@esbuild/win32-x64": "0.25.0"
       }
     },
+    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1555,7 +3838,6 @@
     },
     "node_modules/eslint": {
       "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
       "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
       "dev": true,
       "dependencies": {
@@ -1615,7 +3897,6 @@
     },
     "node_modules/eslint-config-prettier": {
       "version": "10.1.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "bin": {
@@ -1719,14 +4000,21 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-polyfill": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
+      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
+      "license": "MIT"
+    },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true
     },
     "node_modules/eventsource": {
@@ -1741,59 +4029,64 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.0.tgz",
-      "integrity": "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
-      "integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.0.1",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
-        "debug": "4.3.6",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "^2.0.0",
-        "fresh": "2.0.0",
-        "http-errors": "2.0.0",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
         "merge-descriptors": "^2.0.0",
-        "methods": "~1.1.2",
         "mime-types": "^3.0.0",
-        "on-finished": "2.4.1",
-        "once": "1.4.0",
-        "parseurl": "~1.3.3",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "router": "^2.0.0",
-        "safe-buffer": "5.2.1",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
         "send": "^1.1.0",
-        "serve-static": "^2.1.0",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "^2.0.0",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -1801,14 +4094,13 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1850,10 +4142,26 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1884,9 +4192,10 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -1896,29 +4205,12 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dependencies": {
-        "ms": "^2.1.3"
+        "node": ">= 18.0.0"
       },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -1950,9 +4242,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "node_modules/follow-redirects": {
@@ -2011,6 +4303,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2019,6 +4312,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2045,11 +4339,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
-      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
-      "dev": true,
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "engines": {
         "node": ">=18"
       },
@@ -2118,7 +4430,6 @@
     },
     "node_modules/globals": {
       "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
       "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
       "dev": true,
       "engines": {
@@ -2190,24 +4501,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/husky": {
       "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
       "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "bin": {
@@ -2221,14 +4545,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-      "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -2270,10 +4599,20 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -2323,18 +4662,39 @@
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2343,11 +4703,30 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -2355,11 +4734,30 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -2368,6 +4766,15 @@
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -2397,7 +4804,6 @@
     },
     "node_modules/lint-staged": {
       "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.0.tgz",
       "integrity": "sha512-HkpQh69XHxgCjObjejBT3s2ILwNjFx8M3nw+tJ/ssBauDlIpkx2RpqWSi1fBgkXLSSXnbR3iEq1NkVtpvV+FLQ==",
       "dev": true,
       "dependencies": {
@@ -2433,29 +4839,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/lint-staged/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/lint-staged/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
     },
     "node_modules/listr2": {
       "version": "8.3.3",
@@ -2515,9 +4898,9 @@
       }
     },
     "node_modules/log-update/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -2527,12 +4910,12 @@
       }
     },
     "node_modules/log-update/node_modules/is-fullwidth-code-point": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
-      "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "dev": true,
       "dependencies": {
-        "get-east-asian-width": "^1.0.0"
+        "get-east-asian-width": "^1.3.1"
       },
       "engines": {
         "node": ">=18"
@@ -2542,9 +4925,9 @@
       }
     },
     "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
-      "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -2555,6 +4938,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2569,6 +4962,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2577,6 +4971,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2593,14 +4988,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -2615,19 +5002,62 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
-      "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.0.tgz",
-      "integrity": "sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
       "dependencies": {
-        "mime-db": "^1.53.0"
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimetext": {
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.28.tgz",
+      "integrity": "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@babel/runtime-corejs3": "^7.26.0",
+        "js-base64": "^3.7.7",
+        "mime-types": "^2.1.35"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/muratgozel"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -2645,10 +5075,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/miniflare": {
+      "version": "4.20260426.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260426.0.tgz",
+      "integrity": "sha512-KM+v76d04qT+NsPfVKVQEgnnuLNE3uzCCl2QKMTJ5OXor5JbBm1vpkQwQ+l7o5ELCrZ74RnyKhJKLiJyUA39Tw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260426.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -2658,9 +5108,10 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nano-spawn": {
       "version": "1.0.2",
@@ -2674,6 +5125,24 @@
         "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
+    "node_modules/nanoid": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
+      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2684,9 +5153,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -2700,6 +5177,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2711,6 +5189,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -2722,6 +5201,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -2804,8 +5284,38 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/partyserver": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.5.5.tgz",
+      "integrity": "sha512-7zub8oV8Od9dY2aXGrgzhX5GLceaWOg7xB5VWXtDcqt2BWVDIOCAgaF0AmBMSu3AXhJHsFdzPnA8SSZdybXMbQ==",
+      "license": "ISC",
+      "dependencies": {
+        "nanoid": "^5.1.9"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260424.1"
+      }
+    },
+    "node_modules/partysocket": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.18.tgz",
+      "integrity": "sha512-SyuvH9VavWOSa14v6dYdp3yfSUDII4BQB1+TkGOFBkjfZKjnDBiba4fhdhwBlqGBkqw4ea3gTA1DYhSffX24Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-polyfill": "^0.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/path-exists": {
@@ -2821,23 +5331,36 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -2859,9 +5382,10 @@
       }
     },
     "node_modules/pkce-challenge": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
-      "integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
       }
@@ -2877,7 +5401,6 @@
     },
     "node_modules/prettier": {
       "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "bin": {
@@ -2894,6 +5417,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -2917,11 +5441,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -2954,31 +5479,41 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3033,11 +5568,48 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
     },
-    "node_modules/router": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.1.0.tgz",
-      "integrity": "sha512-/m/NSLxeYEgWNtyC+WtNHCF7jbGxOibVWKnn+1Psff4dJGOfoXP+MuC/f2CwSmyiHdOIzYnYFp4W6GxWfekaLA==",
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "is-promise": "^4.0.0",
         "parseurl": "^1.3.3",
         "path-to-regexp": "^8.0.0"
@@ -3069,34 +5641,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -3106,71 +5659,48 @@
       }
     },
     "node_modules/send": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.1.0.tgz",
-      "integrity": "sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
-        "destroy": "^1.2.0",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
-        "fresh": "^0.5.2",
-        "http-errors": "^2.0.0",
-        "mime-types": "^2.1.35",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/send/node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
       },
-      "engines": {
-        "node": ">= 0.6"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/serve-static": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.1.0.tgz",
-      "integrity": "sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "parseurl": "^1.3.3",
-        "send": "^1.0.0"
+        "send": "^1.2.0"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -3178,11 +5708,66 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -3194,7 +5779,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3203,6 +5787,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -3218,12 +5803,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3236,6 +5822,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3253,6 +5840,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3296,9 +5884,9 @@
       }
     },
     "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -3308,9 +5896,10 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3328,7 +5917,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -3342,12 +5930,11 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -3401,9 +5988,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "engines": {
         "node": ">=18.12"
@@ -3412,9 +5999,14 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "optional": true
+    },
     "node_modules/tsx": {
       "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
       "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
       "dev": true,
       "dependencies": {
@@ -3444,9 +6036,10 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.0.tgz",
-      "integrity": "sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -3458,7 +6051,6 @@
     },
     "node_modules/typescript": {
       "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "bin": {
@@ -3471,7 +6063,6 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.34.0.tgz",
       "integrity": "sha512-MRpfN7uYjTrTGigFCt8sRyNqJFhjN0WwZecldaqhWm+wy0gaRt8Edb/3cuUy0zdq2opJWT6iXINKAtewnDOltQ==",
       "dev": true,
       "dependencies": {
@@ -3491,11 +6082,29 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -3505,6 +6114,37 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3512,14 +6152,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/vary": {
@@ -3534,7 +6166,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3554,11 +6185,127 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+    "node_modules/workerd": {
+      "version": "1.20260426.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260426.1.tgz",
+      "integrity": "sha512-ELvGgN8c9oo+E6EPyecxk1TEf6/eAK4TxxQTW5mQ87C7jbjCzhMbg0P2ije49UBHV0dkBYPJcJvcklUltipl2A==",
       "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260426.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260426.1",
+        "@cloudflare/workerd-linux-64": "1.20260426.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260426.1",
+        "@cloudflare/workerd-windows-64": "1.20260426.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.86.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.86.0.tgz",
+      "integrity": "sha512-9aa/gbF/HiUeeUEwyQpW5LDPBEzyt7iaE6xHwm0vk2Ly8A6J+jh03pzchqVnCCWR832mNyA28MD8oAYt0Kfvlw==",
+      "dev": true,
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260426.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260426.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.3.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260426.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/wrangler/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",
@@ -3572,10 +6319,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "engines": {
         "node": ">=12"
       },
@@ -3586,7 +6332,45 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yaml": {
       "version": "2.8.0",
@@ -3598,6 +6382,32 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yocto-queue": {
@@ -3612,20 +6422,58 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.3.tgz",
-      "integrity": "sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,14 +8,18 @@
     "tempo-mcp-server": "./build/index.js"
   },
   "scripts": {
-    "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "build": "tsc -p tsconfig.node.json && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "start": "node build/index.js",
     "dev": "tsx watch src/index.ts",
     "inspect": "npx @modelcontextprotocol/inspector tsx src/index.ts",
     "prepare": "npm run build && husky",
     "lint": "eslint",
     "format": "prettier . --write",
-    "format:check": "prettier . --check"
+    "format:check": "prettier . --check",
+    "remote:dev": "wrangler dev",
+    "remote:deploy": "wrangler deploy",
+    "remote:typecheck": "tsc --noEmit -p tsconfig.worker.json",
+    "remote:tail": "wrangler tail"
   },
   "files": [
     "build",
@@ -45,11 +49,13 @@
   },
   "homepage": "https://github.com/ivelin-web/tempo-mcp-server#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.6.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.6.7",
-    "zod": "^3.24.2"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260426.1",
+    "agents": "^0.11.9",
     "@eslint/js": "^9.28.0",
     "@types/node": "^20.11.0",
     "eslint": "^9.28.0",
@@ -60,7 +66,8 @@
     "prettier": "3.5.3",
     "tsx": "^4.7.0",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "wrangler": "^4.86.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ function validateEnv() {
     // Format and display validation errors
     console.error('[ERROR] Environment validation failed:');
     if (error instanceof ZodError) {
-      error.errors.forEach((err) => {
+      error.issues.forEach((err) => {
         console.error(`- ${err.path.join('.')}: ${err.message}`);
       });
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,18 @@
 #!/usr/bin/env node
 /**
- * Tempo MCP Server
+ * Tempo MCP Server — stdio entrypoint.
  *
- * A simple Model Context Protocol server for managing Tempo worklogs with TypeScript.
+ * For local clients (Claude Desktop, Cursor, Windsurf) that launch this
+ * binary as a child process and communicate over stdio. The remote/Cloudflare
+ * Worker entrypoint lives in `src/remote/worker.ts` and shares the same
+ * underlying tools/jira factories.
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import config from './config.js';
-import * as tools from './tools.js';
+import { Ctx } from './types.js';
+import { createTools } from './tools.js';
 import {
   retrieveWorklogsSchema,
   createWorklogSchema,
@@ -19,252 +23,296 @@ import {
   getWorklogAnalyticsSchema,
 } from './types.js';
 
-// Create MCP server instance
-const server = new McpServer({
-  name: config.server.name,
-  version: config.server.version,
-});
+async function buildStdioCtx(): Promise<Ctx> {
+  const ctx: Ctx = {
+    tempoApi: {
+      baseUrl: config.tempoApi.baseUrl,
+      token: config.tempoApi.token,
+    },
+    jiraApi: {
+      baseUrl: config.jiraApi.baseUrl,
+      // For 'oauth', the static token field is unused — refreshJira owns it.
+      // We set a sentinel so the factory's cache miss check doesn't short-circuit.
+      token: config.jiraApi.token ?? '',
+      email: config.jiraApi.email,
+      authType: config.jiraApi.authType,
+      tempoAccountCustomFieldId: config.jiraApi.tempoAccountCustomFieldId,
+    },
+  };
 
-// Tool: retrieveWorklogs - fetch worklogs between two dates
-server.tool(
-  'retrieveWorklogs',
-  retrieveWorklogsSchema.shape,
-  async ({ startDate, endDate }) => {
-    try {
-      const result = await tools.retrieveWorklogs(startDate, endDate);
-      return {
-        content: result.content,
-        ...(result.isError && { isError: true }),
-      };
-    } catch (error) {
-      console.error(
-        `[ERROR] retrieveWorklogs failed: ${error instanceof Error ? error.message : String(error)}`,
+  if (config.jiraApi.authType === 'oauth') {
+    // Dynamic import keeps oauth.ts (which uses fs/http/child_process) out of
+    // the Worker bundle. Stdio binary still works because Node resolves the
+    // import normally.
+    const clientId = config.jiraApi.oauthClientId;
+    const clientSecret = config.jiraApi.oauthClientSecret;
+    if (!clientId || !clientSecret) {
+      throw new Error(
+        'JIRA_OAUTH_CLIENT_ID and JIRA_OAUTH_CLIENT_SECRET are required for OAuth authentication',
       );
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Error retrieving worklogs: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
     }
-  },
-);
 
-// Tool: createWorklog - create a single worklog entry
-server.tool(
-  'createWorklog',
-  createWorklogSchema.shape,
-  async ({
-    issueKey,
-    timeSpentHours,
-    date,
-    description,
-    startTime,
-    attributes,
-  }) => {
-    try {
-      const result = await tools.createWorklog(
+    const { getOAuthToken } = await import('./oauth.js');
+    const oauthCfg = {
+      clientId,
+      clientSecret,
+      siteUrl: config.jiraApi.baseUrl,
+    };
+    ctx.refreshJira = async () => {
+      const { token, cloudId } = await getOAuthToken(oauthCfg);
+      return {
+        token,
+        baseUrl: `https://api.atlassian.com/ex/jira/${cloudId}`,
+      };
+    };
+  }
+
+  return ctx;
+}
+
+async function startServer(): Promise<void> {
+  try {
+    const ctx = await buildStdioCtx();
+    const tools = createTools(ctx);
+
+    const server = new McpServer({
+      name: config.server.name,
+      version: config.server.version,
+    });
+
+    server.registerTool(
+      'retrieveWorklogs',
+      { inputSchema: retrieveWorklogsSchema.shape },
+      async ({ startDate, endDate }) => {
+        try {
+          const result = await tools.retrieveWorklogs(startDate, endDate);
+          return {
+            content: result.content,
+            ...(result.isError && { isError: true }),
+          };
+        } catch (error) {
+          console.error(
+            `[ERROR] retrieveWorklogs failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error retrieving worklogs: ${error instanceof Error ? error.message : String(error)}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    );
+
+    server.registerTool(
+      'createWorklog',
+      { inputSchema: createWorklogSchema.shape },
+      async ({
         issueKey,
         timeSpentHours,
         date,
         description,
         startTime,
         attributes,
-      );
-      return {
-        content: result.content,
-        ...(result.isError && { isError: true }),
-      };
-    } catch (error) {
-      console.error(
-        `[ERROR] createWorklog failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Error creating worklog: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
-    }
-  },
-);
+      }) => {
+        try {
+          const result = await tools.createWorklog(
+            issueKey,
+            timeSpentHours,
+            date,
+            description,
+            startTime,
+            attributes,
+          );
+          return {
+            content: result.content,
+            ...(result.isError && { isError: true }),
+          };
+        } catch (error) {
+          console.error(
+            `[ERROR] createWorklog failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error creating worklog: ${error instanceof Error ? error.message : String(error)}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    );
 
-// Tool: bulkCreateWorklogs - create multiple worklog entries at once
-server.tool(
-  'bulkCreateWorklogs',
-  bulkCreateWorklogsSchema.shape,
-  async ({ worklogEntries }) => {
-    try {
-      const result = await tools.bulkCreateWorklogs(worklogEntries);
-      return {
-        content: result.content,
-        ...(result.isError && { isError: true }),
-      };
-    } catch (error) {
-      console.error(
-        `[ERROR] bulkCreateWorklogs failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Error creating multiple worklogs: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
-    }
-  },
-);
+    server.registerTool(
+      'bulkCreateWorklogs',
+      { inputSchema: bulkCreateWorklogsSchema.shape },
+      async ({ worklogEntries }) => {
+        try {
+          const result = await tools.bulkCreateWorklogs(worklogEntries);
+          return {
+            content: result.content,
+            ...(result.isError && { isError: true }),
+          };
+        } catch (error) {
+          console.error(
+            `[ERROR] bulkCreateWorklogs failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error creating multiple worklogs: ${error instanceof Error ? error.message : String(error)}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    );
 
-// Tool: editWorklog - modify an existing worklog entry
-server.tool(
-  'editWorklog',
-  editWorklogSchema.shape,
-  async ({
-    worklogId,
-    timeSpentHours,
-    description,
-    date,
-    startTime,
-    attributes,
-  }) => {
-    try {
-      const result = await tools.editWorklog(
+    server.registerTool(
+      'editWorklog',
+      { inputSchema: editWorklogSchema.shape },
+      async ({
         worklogId,
         timeSpentHours,
-        description || null,
-        date || null,
-        startTime || undefined,
+        description,
+        date,
+        startTime,
         attributes,
-      );
-      return {
-        content: result.content,
-        ...(result.isError && { isError: true }),
-      };
-    } catch (error) {
-      console.error(
-        `[ERROR] editWorklog failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Error editing worklog: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
-    }
-  },
-);
+      }) => {
+        try {
+          const result = await tools.editWorklog(
+            worklogId,
+            timeSpentHours,
+            description ?? null,
+            date ?? null,
+            startTime,
+            attributes,
+          );
+          return {
+            content: result.content,
+            ...(result.isError && { isError: true }),
+          };
+        } catch (error) {
+          console.error(
+            `[ERROR] editWorklog failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error editing worklog: ${error instanceof Error ? error.message : String(error)}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    );
 
-// Tool: deleteWorklog - remove an existing worklog entry
-server.tool(
-  'deleteWorklog',
-  deleteWorklogSchema.shape,
-  async ({ worklogId }) => {
-    try {
-      const result = await tools.deleteWorklog(worklogId);
-      return {
-        content: result.content,
-        ...(result.isError && { isError: true }),
-      };
-    } catch (error) {
-      console.error(
-        `[ERROR] deleteWorklog failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Error deleting worklog: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
-    }
-  },
-);
+    server.registerTool(
+      'deleteWorklog',
+      { inputSchema: deleteWorklogSchema.shape },
+      async ({ worklogId }) => {
+        try {
+          const result = await tools.deleteWorklog(worklogId);
+          return {
+            content: result.content,
+            ...(result.isError && { isError: true }),
+          };
+        } catch (error) {
+          console.error(
+            `[ERROR] deleteWorklog failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error deleting worklog: ${error instanceof Error ? error.message : String(error)}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    );
 
-// Tool: getMissingWorklogDays - find working days with insufficient logged time
-server.tool(
-  'getMissingWorklogDays',
-  "Find working days in a date range where the user's logged time is below the expected hours from their Tempo user-schedule. Holidays and non-working days are skipped automatically. Returns days with their expected vs logged hours, plus a per-issue breakdown for partially-logged days. Requires the 'Schemes' scope on the Tempo API token (in addition to 'Worklogs').",
-  getMissingWorklogDaysSchema.shape,
-  async ({ startDate, endDate, minHoursPerDay }) => {
-    try {
-      const result = await tools.getMissingWorklogDays(
-        startDate,
-        endDate,
-        minHoursPerDay,
-      );
-      // Preserve isError so date-range / MAX_PAGES / 403 / etc. surface
-      // as proper MCP errors, not successful responses with error text.
-      return {
-        content: result.content,
-        ...(result.isError && { isError: true }),
-      };
-    } catch (error) {
-      console.error(
-        `[ERROR] getMissingWorklogDays failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Error getting missing worklog days: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
-    }
-  },
-);
+    server.registerTool(
+      'getMissingWorklogDays',
+      {
+        description:
+          "Find working days in a date range where the user's logged time is below the expected hours from their Tempo user-schedule. Holidays and non-working days are skipped automatically. Returns days with their expected vs logged hours, plus a per-issue breakdown for partially-logged days. Requires the 'Schemes' scope on the Tempo API token (in addition to 'Worklogs').",
+        inputSchema: getMissingWorklogDaysSchema.shape,
+      },
+      async ({ startDate, endDate, minHoursPerDay }) => {
+        try {
+          const result = await tools.getMissingWorklogDays(
+            startDate,
+            endDate,
+            minHoursPerDay,
+          );
+          return {
+            content: result.content,
+            ...(result.isError && { isError: true }),
+          };
+        } catch (error) {
+          console.error(
+            `[ERROR] getMissingWorklogDays failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error getting missing worklog days: ${error instanceof Error ? error.message : String(error)}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    );
 
-// Tool: getWorklogAnalytics - aggregate worklogs by issue/account/day/week/month
-server.tool(
-  'getWorklogAnalytics',
-  "Aggregate worklogs in a date range and return hours, worklog count, and percentage per group, sorted by hours descending. groupBy options: 'issue' (default), 'account', 'day', 'week' (ISO 8601), 'month'. Note: 'account' grouping reads the _Account_ work attribute on each worklog — worklogs without an account attribute are bucketed as 'No account', so this grouping is only meaningful if your team uses Tempo accounts.",
-  getWorklogAnalyticsSchema.shape,
-  async ({ startDate, endDate, groupBy }) => {
-    try {
-      const result = await tools.getWorklogAnalytics(
-        startDate,
-        endDate,
-        groupBy,
-      );
-      // Preserve isError so date-range / MAX_PAGES / etc. surface as
-      // proper MCP errors, not successful responses with error text.
-      return {
-        content: result.content,
-        ...(result.isError && { isError: true }),
-      };
-    } catch (error) {
-      console.error(
-        `[ERROR] getWorklogAnalytics failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Error getting worklog analytics: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
-    }
-  },
-);
+    server.registerTool(
+      'getWorklogAnalytics',
+      {
+        description:
+          "Aggregate worklogs in a date range and return hours, worklog count, and percentage per group, sorted by hours descending. groupBy options: 'issue' (default), 'account', 'day', 'week' (ISO 8601), 'month'. Note: 'account' grouping reads the _Account_ work attribute on each worklog — worklogs without an account attribute are bucketed as 'No account', so this grouping is only meaningful if your team uses Tempo accounts.",
+        inputSchema: getWorklogAnalyticsSchema.shape,
+      },
+      async ({ startDate, endDate, groupBy }) => {
+        try {
+          const result = await tools.getWorklogAnalytics(
+            startDate,
+            endDate,
+            groupBy,
+          );
+          return {
+            content: result.content,
+            ...(result.isError && { isError: true }),
+          };
+        } catch (error) {
+          console.error(
+            `[ERROR] getWorklogAnalytics failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error getting worklog analytics: ${error instanceof Error ? error.message : String(error)}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    );
 
-async function startServer(): Promise<void> {
-  try {
     const transport = new StdioServerTransport();
     await server.connect(transport);
     console.error('[INFO] MCP Server started successfully');
@@ -281,7 +329,7 @@ async function startServer(): Promise<void> {
   }
 }
 
-startServer().catch((error) => {
+startServer().catch((error: unknown) => {
   console.error(
     `[ERROR] Unhandled exception: ${error instanceof Error ? error.message : String(error)}`,
   );

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -1,56 +1,23 @@
 import axios, { AxiosInstance } from 'axios';
-import { JiraUser, issueIdSchema, idOrKeySchema } from './types.js';
-import config from './config.js';
-import { getOAuthToken, OAuthConfig } from './oauth.js';
+import { JiraUser, issueIdSchema, idOrKeySchema, Ctx } from './types.js';
 
-// Build authorization header based on auth type
-function getAuthHeader(): string {
-  if (config.jiraApi.authType === 'bearer') {
-    return `Bearer ${config.jiraApi.token}`;
-  }
-  // Basic auth (default)
-  return `Basic ${Buffer.from(`${config.jiraApi.email}:${config.jiraApi.token}`).toString('base64')}`;
+export interface JiraClient {
+  getCurrentUserAccountId(): Promise<string>;
+  getIssueInfoById(
+    issueId: string | number,
+  ): Promise<{ key: string; summary: string }>;
+  getIssue(idOrKey: string | number): Promise<{
+    id: string;
+    key: string;
+    tempoAccountId?: string;
+  }>;
 }
 
-let _jiraApi: AxiosInstance | null = null;
-
-async function getJiraApi(): Promise<AxiosInstance> {
-  if (config.jiraApi.authType === 'oauth') {
-    const oauthCfg: OAuthConfig = {
-      clientId: config.jiraApi.oauthClientId!,
-      clientSecret: config.jiraApi.oauthClientSecret!,
-      siteUrl: config.jiraApi.baseUrl,
-    };
-    const { token, cloudId } = await getOAuthToken(oauthCfg);
-
-    if (!_jiraApi) {
-      _jiraApi = axios.create({
-        baseURL: `https://api.atlassian.com/ex/jira/${cloudId}`,
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      });
-    }
-    _jiraApi.defaults.headers.common.Authorization = `Bearer ${token}`;
-    return _jiraApi;
-  }
-
-  // Jira API client with authentication
-  if (!_jiraApi) {
-    _jiraApi = axios.create({
-      baseURL: config.jiraApi.baseUrl,
-      headers: {
-        Authorization: getAuthHeader(),
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-    });
-  }
-  return _jiraApi;
+function basicAuthHeader(email: string, token: string): string {
+  // btoa is available in both Node 16+ and the Workers runtime.
+  return `Basic ${btoa(`${email}:${token}`)}`;
 }
 
-// Standardized error handling for Jira API
 function formatJiraError(error: unknown, context: string): Error {
   if (axios.isAxiosError(error)) {
     const statusCode = error.response?.status;
@@ -64,108 +31,153 @@ function formatJiraError(error: unknown, context: string): Error {
 }
 
 /**
- * Get user's account ID.
+ * Build a Jira API client bound to a specific Ctx.
  *
- * Uses /myself for all auth types — it returns the authenticated user's own
- * accountId regardless of basic / bearer / oauth, and avoids the email-based
- * /user/search which can return empty results when email visibility is
- * restricted by Atlassian privacy settings or scoped API token limits.
- *
- * Falls back to email search for basic auth if /myself fails, to preserve
- * backwards compatibility with edge cases where /myself is unavailable.
+ * The returned object lazily constructs an Axios instance, refreshing it when
+ * the Ctx-provided token rotates (OAuth path). For basic/bearer this is a
+ * one-shot construction.
  */
-export async function getCurrentUserAccountId(): Promise<string> {
-  const jiraApi = await getJiraApi();
+export function createJiraClient(ctx: Ctx): JiraClient {
+  let cached: { token: string; baseUrl: string; client: AxiosInstance } | null =
+    null;
 
-  try {
-    const response = await jiraApi.get<JiraUser>('/rest/api/3/myself');
-    return response.data.accountId;
-  } catch (myselfError) {
-    // For basic auth, try the legacy email-search fallback
-    if (config.jiraApi.authType === 'basic' && config.jiraApi.email) {
+  async function client(): Promise<AxiosInstance> {
+    let token = ctx.jiraApi.token;
+    let baseUrl = ctx.jiraApi.baseUrl;
+
+    if (ctx.refreshJira) {
+      const r = await ctx.refreshJira();
+      token = r.token;
+      if (r.baseUrl) baseUrl = r.baseUrl;
+    }
+
+    if (cached && cached.token === token && cached.baseUrl === baseUrl) {
+      return cached.client;
+    }
+
+    const authHeader =
+      ctx.jiraApi.authType === 'basic'
+        ? basicAuthHeader(ctx.jiraApi.email ?? '', token)
+        : `Bearer ${token}`;
+
+    const instance = axios.create({
+      baseURL: baseUrl,
+      headers: {
+        Authorization: authHeader,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    });
+    cached = { token, baseUrl, client: instance };
+    return instance;
+  }
+
+  return {
+    /**
+     * Get user's account ID.
+     *
+     * Uses /myself for all auth types — it returns the authenticated user's own
+     * accountId regardless of basic / bearer / oauth, and avoids the email-based
+     * /user/search which can return empty results when email visibility is
+     * restricted by Atlassian privacy settings or scoped API token limits.
+     *
+     * Falls back to email search for basic auth if /myself fails, to preserve
+     * backwards compatibility with edge cases where /myself is unavailable.
+     */
+    async getCurrentUserAccountId(): Promise<string> {
+      const jiraApi = await client();
       try {
-        const response = await jiraApi.get<JiraUser[]>(
-          '/rest/api/3/user/search',
-          { params: { query: config.jiraApi.email } },
-        );
-        const users = response.data;
-        const user = users?.find(
-          (u) => u.emailAddress === config.jiraApi.email,
-        );
-        if (user) return user.accountId;
-        throw new Error(`No user found with email: ${config.jiraApi.email}`);
-      } catch (searchError) {
-        throw formatJiraError(searchError, 'Failed to get user account ID');
+        const response = await jiraApi.get<JiraUser>('/rest/api/3/myself');
+        return response.data.accountId;
+      } catch (myselfError) {
+        if (ctx.jiraApi.authType === 'basic' && ctx.jiraApi.email) {
+          try {
+            const response = await jiraApi.get<JiraUser[]>(
+              '/rest/api/3/user/search',
+              { params: { query: ctx.jiraApi.email } },
+            );
+            const users = response.data;
+            const user = users?.find(
+              (u) => u.emailAddress === ctx.jiraApi.email,
+            );
+            if (user) return user.accountId;
+            if (users.length === 1) return users[0].accountId;
+
+            const myselfMessage = formatJiraError(
+              myselfError,
+              'Jira /myself failed',
+            ).message;
+            throw new Error(
+              `No user found with email: ${ctx.jiraApi.email}. ${myselfMessage}`,
+            );
+          } catch (searchError) {
+            throw formatJiraError(searchError, 'Failed to get user account ID');
+          }
+        }
+        throw formatJiraError(myselfError, 'Failed to get user account ID');
       }
-    }
-    throw formatJiraError(myselfError, 'Failed to get user account ID');
-  }
-}
+    },
 
-/**
- * Get Jira issue key + summary by ID.
- * Used by tools that need to render human-friendly issue labels like
- * "PPSG-50 — [AI/Backend] Structural AI Generation of Localized".
- */
-export async function getIssueInfoById(
-  issueId: string | number,
-): Promise<{ key: string; summary: string }> {
-  try {
-    const result = issueIdSchema().safeParse(issueId);
-    if (!result.success) {
-      throw new Error(
-        result.error.errors[0].message || 'Issue ID validation failed',
-      );
-    }
+    /**
+     * Get Jira issue key + summary by ID.
+     */
+    async getIssueInfoById(
+      issueId: string | number,
+    ): Promise<{ key: string; summary: string }> {
+      try {
+        const result = issueIdSchema().safeParse(issueId);
+        if (!result.success) {
+          throw new Error(
+            result.error.issues[0].message || 'Issue ID validation failed',
+          );
+        }
+        const jiraApi = await client();
+        const response = await jiraApi.get(`/rest/api/3/issue/${issueId}`);
+        return {
+          key: response.data.key,
+          summary: response.data.fields?.summary || '',
+        };
+      } catch (error) {
+        throw formatJiraError(
+          error,
+          `Failed to get issue info for ID ${issueId}`,
+        );
+      }
+    },
 
-    const jiraApi = await getJiraApi();
-    const response = await jiraApi.get(`/rest/api/3/issue/${issueId}`);
-    return {
-      key: response.data.key,
-      summary: response.data.fields?.summary || '',
-    };
-  } catch (error) {
-    throw formatJiraError(error, `Failed to get issue info for ID ${issueId}`);
-  }
-}
+    /**
+     * Get Jira issue from issue ID or key.
+     */
+    async getIssue(idOrKey: string | number): Promise<{
+      id: string;
+      key: string;
+      tempoAccountId?: string;
+    }> {
+      try {
+        const result = idOrKeySchema().safeParse(idOrKey);
+        if (!result.success) {
+          throw new Error(
+            result.error.issues[0].message ||
+              'Issue identifier validation failed',
+          );
+        }
+        const jiraApi = await client();
+        const response = await jiraApi.get(`/rest/api/3/issue/${idOrKey}`);
 
-/**
- * Get Jira issue from issue ID or key
- */
-export async function getIssue(idOrKey: string | number): Promise<{
-  id: string;
-  key: string;
-  /** If the issue has a Tempo account associated, this will be the account ID */
-  tempoAccountId?: string;
-}> {
-  try {
-    // Validate issue ID using the schema
-    const result = idOrKeySchema().safeParse(idOrKey);
-    if (!result.success) {
-      throw new Error(
-        result.error.errors[0].message || 'Issue identifier validation failed',
-      );
-    }
+        const tempoAccountId = ctx.jiraApi.tempoAccountCustomFieldId
+          ? response.data.fields[
+              `customfield_${ctx.jiraApi.tempoAccountCustomFieldId}`
+            ]?.id
+          : undefined;
 
-    const jiraApi = await getJiraApi();
-    const response = await jiraApi.get(`/rest/api/3/issue/${idOrKey}`);
-
-    // Find the Tempo account key
-    const tempoAccountId = config.jiraApi.tempoAccountCustomFieldId
-      ? response.data.fields[
-          `customfield_${config.jiraApi.tempoAccountCustomFieldId}`
-        ].id
-      : undefined;
-
-    const id = response.data.id;
-    const key = response.data.key;
-
-    return {
-      id,
-      key,
-      ...(tempoAccountId ? { tempoAccountId } : {}),
-    };
-  } catch (error) {
-    throw formatJiraError(error, `Failed to get issue for ${idOrKey}`);
-  }
+        return {
+          id: response.data.id,
+          key: response.data.key,
+          ...(tempoAccountId ? { tempoAccountId } : {}),
+        };
+      } catch (error) {
+        throw formatJiraError(error, `Failed to get issue for ${idOrKey}`);
+      }
+    },
+  };
 }

--- a/src/remote/agent.ts
+++ b/src/remote/agent.ts
@@ -1,0 +1,221 @@
+/**
+ * Per-request McpServer factory.
+ *
+ * Each MCP request loads encrypted credentials from KV, calls
+ * `buildMcpServer(creds)` to construct a fresh McpServer with all 7 tools
+ * registered, and dispatches one JSON-RPC roundtrip via Cloudflare's
+ * `createMcpHandler`. The McpServer is single-use — MCP SDK ≥1.26 throws on
+ * server/transport reuse, and stateless rebuild keeps tenants isolated.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Ctx } from '../types.js';
+import { createTools } from '../tools.js';
+import {
+  retrieveWorklogsSchema,
+  createWorklogSchema,
+  bulkCreateWorklogsSchema,
+  editWorklogSchema,
+  deleteWorklogSchema,
+  getMissingWorklogDaysSchema,
+  getWorklogAnalyticsSchema,
+} from '../types.js';
+import { UserCredentials } from './storage.js';
+
+const SERVER_NAME = 'tempo-mcp-server';
+const SERVER_VERSION = '2.0.0-remote';
+
+export function ctxFromCreds(creds: UserCredentials): Ctx {
+  return {
+    tempoApi: {
+      baseUrl: 'https://api.tempo.io/4',
+      token: creds.tempoApiToken,
+    },
+    jiraApi: {
+      baseUrl: creds.jiraBaseUrl,
+      token: creds.jiraApiToken,
+      email: creds.jiraEmail,
+      authType: creds.jiraAuthType,
+      tempoAccountCustomFieldId: creds.jiraTempoAccountCustomFieldId,
+    },
+  };
+}
+
+export function buildMcpServer(creds: UserCredentials): McpServer {
+  const ctx = ctxFromCreds(creds);
+  const tools = createTools(ctx);
+
+  const server = new McpServer({
+    name: SERVER_NAME,
+    version: SERVER_VERSION,
+  });
+
+  server.registerTool(
+    'retrieveWorklogs',
+    { inputSchema: retrieveWorklogsSchema.shape },
+    async ({ startDate, endDate }) => {
+      try {
+        const result = await tools.retrieveWorklogs(startDate, endDate);
+        return {
+          content: result.content,
+          ...(result.isError && { isError: true }),
+        };
+      } catch (error) {
+        return errorResponse('retrieveWorklogs', error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'createWorklog',
+    { inputSchema: createWorklogSchema.shape },
+    async ({
+      issueKey,
+      timeSpentHours,
+      date,
+      description,
+      startTime,
+      attributes,
+    }) => {
+      try {
+        const result = await tools.createWorklog(
+          issueKey,
+          timeSpentHours,
+          date,
+          description,
+          startTime,
+          attributes,
+        );
+        return {
+          content: result.content,
+          ...(result.isError && { isError: true }),
+        };
+      } catch (error) {
+        return errorResponse('createWorklog', error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'bulkCreateWorklogs',
+    { inputSchema: bulkCreateWorklogsSchema.shape },
+    async ({ worklogEntries }) => {
+      try {
+        const result = await tools.bulkCreateWorklogs(worklogEntries);
+        return {
+          content: result.content,
+          ...(result.isError && { isError: true }),
+        };
+      } catch (error) {
+        return errorResponse('bulkCreateWorklogs', error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'editWorklog',
+    { inputSchema: editWorklogSchema.shape },
+    async ({
+      worklogId,
+      timeSpentHours,
+      description,
+      date,
+      startTime,
+      attributes,
+    }) => {
+      try {
+        const result = await tools.editWorklog(
+          worklogId,
+          timeSpentHours,
+          description ?? null,
+          date ?? null,
+          startTime,
+          attributes,
+        );
+        return {
+          content: result.content,
+          ...(result.isError && { isError: true }),
+        };
+      } catch (error) {
+        return errorResponse('editWorklog', error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'deleteWorklog',
+    { inputSchema: deleteWorklogSchema.shape },
+    async ({ worklogId }) => {
+      try {
+        const result = await tools.deleteWorklog(worklogId);
+        return {
+          content: result.content,
+          ...(result.isError && { isError: true }),
+        };
+      } catch (error) {
+        return errorResponse('deleteWorklog', error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'getMissingWorklogDays',
+    {
+      description:
+        "Find working days in a date range where the user's logged time is below the expected hours from their Tempo user-schedule. Holidays and non-working days are skipped automatically. Returns days with their expected vs logged hours, plus a per-issue breakdown for partially-logged days. Requires the 'Schemes' scope on the Tempo API token (in addition to 'Worklogs').",
+      inputSchema: getMissingWorklogDaysSchema.shape,
+    },
+    async ({ startDate, endDate, minHoursPerDay }) => {
+      try {
+        const result = await tools.getMissingWorklogDays(
+          startDate,
+          endDate,
+          minHoursPerDay,
+        );
+        return {
+          content: result.content,
+          ...(result.isError && { isError: true }),
+        };
+      } catch (error) {
+        return errorResponse('getMissingWorklogDays', error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'getWorklogAnalytics',
+    {
+      description:
+        "Aggregate worklogs in a date range and return hours, worklog count, and percentage per group, sorted by hours descending. groupBy options: 'issue' (default), 'account', 'day', 'week' (ISO 8601), 'month'. Note: 'account' grouping reads the _Account_ work attribute on each worklog — worklogs without an account attribute are bucketed as 'No account', so this grouping is only meaningful if your team uses Tempo accounts.",
+      inputSchema: getWorklogAnalyticsSchema.shape,
+    },
+    async ({ startDate, endDate, groupBy }) => {
+      try {
+        const result = await tools.getWorklogAnalytics(
+          startDate,
+          endDate,
+          groupBy,
+        );
+        return {
+          content: result.content,
+          ...(result.isError && { isError: true }),
+        };
+      } catch (error) {
+        return errorResponse('getWorklogAnalytics', error);
+      }
+    },
+  );
+
+  return server;
+}
+
+function errorResponse(toolName: string, error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[ERROR] ${toolName} failed: ${message}`);
+  return {
+    content: [
+      { type: 'text' as const, text: `Error in ${toolName}: ${message}` },
+    ],
+    isError: true,
+  };
+}

--- a/src/remote/setup.ts
+++ b/src/remote/setup.ts
@@ -1,0 +1,365 @@
+/**
+ * Onboarding pages: GET/POST /setup.
+ *
+ * Flow:
+ *  1. GET /setup — server-rendered HTML form. Six fields (Tempo + Jira creds).
+ *  2. POST /setup — validates, mints a `userId`, encrypts + stores creds in
+ *     KV, and renders a success page with the MCP URL the user pastes into
+ *     Claude/ChatGPT.
+ *
+ * Security notes:
+ *  - All HTML is server-rendered with no client-side framework. The submitted
+ *    secrets reach the Worker via TLS POST and are AES-GCM encrypted in KV
+ *    before any response is sent.
+ *  - The success page renders the MCP URL as text + a copy button. We never
+ *    redirect the browser to that URL (would put it in history).
+ *  - We escape user-controlled values everywhere they appear in HTML to keep
+ *    a future "show what I entered" path safe (currently we never echo back).
+ */
+
+import {
+  generateId,
+  putCredentials,
+  StorageEnv,
+  UserCredentials,
+} from './storage.js';
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const STYLE = `
+  :root { color-scheme: light dark; --fg: #1a1a1a; --muted: #6b7280; --bg: #f9fafb;
+          --card: #ffffff; --border: #e5e7eb; --accent: #2563eb; --error: #dc2626;
+          --success: #059669; --code-bg: #f3f4f6; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg: #f3f4f6; --muted: #9ca3af; --bg: #0f172a; --card: #1e293b;
+            --border: #334155; --code-bg: #0b1220; }
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+         background: var(--bg); color: var(--fg); line-height: 1.5; }
+  .wrap { max-width: 640px; margin: 0 auto; padding: 32px 20px; }
+  h1 { font-size: 24px; margin: 0 0 4px; }
+  h2 { font-size: 18px; margin: 24px 0 8px; }
+  p { color: var(--muted); margin: 0 0 16px; }
+  .card { background: var(--card); border: 1px solid var(--border); border-radius: 12px;
+          padding: 24px; margin-top: 16px; }
+  label { display: block; font-weight: 500; margin: 16px 0 4px; font-size: 14px; }
+  label .req { color: var(--error); }
+  label .hint { font-weight: 400; color: var(--muted); font-size: 12px; margin-left: 4px; }
+  input[type=text], input[type=email], input[type=url], input[type=password], select {
+    width: 100%; padding: 9px 12px; border: 1px solid var(--border); border-radius: 8px;
+    background: var(--bg); color: var(--fg); font-size: 14px; font-family: inherit;
+  }
+  input:focus, select:focus { outline: 2px solid var(--accent); outline-offset: -1px; border-color: var(--accent); }
+  .row { display: flex; gap: 12px; align-items: flex-start; flex-wrap: wrap; }
+  .row > div { flex: 1; min-width: 240px; }
+  button { background: var(--accent); color: #fff; border: 0; padding: 10px 18px;
+           border-radius: 8px; font-size: 14px; font-weight: 500; cursor: pointer;
+           margin-top: 24px; }
+  button:hover { filter: brightness(1.1); }
+  .err { color: var(--error); background: rgba(220,38,38,0.08); border: 1px solid rgba(220,38,38,0.3);
+         padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; font-size: 14px; }
+  .ok { color: var(--success); background: rgba(5,150,105,0.08); border: 1px solid rgba(5,150,105,0.3);
+        padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; font-size: 14px; }
+  code, .url { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+               background: var(--code-bg); padding: 2px 6px; border-radius: 4px; font-size: 13px; }
+  .url-box { background: var(--code-bg); padding: 14px; border-radius: 8px; word-break: break-all;
+             border: 1px solid var(--border); font-size: 13px; user-select: all; cursor: text; }
+  .copy-btn { margin-top: 8px; background: transparent; color: var(--accent);
+              border: 1px solid var(--accent); padding: 6px 14px; font-size: 13px; }
+  details { margin-top: 12px; }
+  summary { cursor: pointer; color: var(--accent); font-size: 14px; }
+  ul { padding-left: 20px; color: var(--muted); }
+  ul li { margin: 4px 0; font-size: 14px; }
+  .warn { background: rgba(234,179,8,0.08); border: 1px solid rgba(234,179,8,0.4);
+          color: #92400e; padding: 12px 16px; border-radius: 8px; font-size: 14px; }
+  @media (prefers-color-scheme: dark) { .warn { color: #fde68a; } }
+  hr { border: 0; border-top: 1px solid var(--border); margin: 24px 0; }
+`;
+
+const SCRIPT_TOGGLE_AUTH = `
+  function syncAuthType() {
+    var t = (document.querySelector('input[name=jiraAuthType]:checked') || {}).value;
+    var emailRow = document.getElementById('email-row');
+    var emailInput = document.getElementById('jiraEmail');
+    if (!emailRow || !emailInput) return;
+    var basic = (t !== 'bearer');
+    emailRow.style.display = basic ? '' : 'none';
+    emailInput.required = basic;
+  }
+  document.addEventListener('DOMContentLoaded', function () {
+    syncAuthType();
+    document.querySelectorAll('input[name=jiraAuthType]').forEach(function (el) {
+      el.addEventListener('change', syncAuthType);
+    });
+  });
+`;
+
+const SCRIPT_COPY = `
+  function copyUrl(id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    navigator.clipboard.writeText(el.textContent.trim()).then(function () {
+      var btn = document.getElementById(id + '-copy');
+      if (btn) { var orig = btn.textContent; btn.textContent = 'Copied!'; setTimeout(function () { btn.textContent = orig; }, 1500); }
+    });
+  }
+`;
+
+function layout(title: string, body: string, script = ''): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="referrer" content="no-referrer">
+<title>${escapeHtml(title)}</title>
+<style>${STYLE}</style>
+</head>
+<body>
+<div class="wrap">${body}</div>
+${script ? `<script>${script}</script>` : ''}
+</body>
+</html>`;
+}
+
+export function renderSetupPage(
+  error?: string,
+  prev?: Partial<UserCredentials>,
+): string {
+  const e = error ? `<div class="err">${escapeHtml(error)}</div>` : '';
+  const v = (k: keyof UserCredentials) =>
+    escapeHtml((prev?.[k] as string) ?? '');
+  // Bearer is currently disabled (see below); always default to basic on re-render.
+  const checkedBasic = 'checked';
+  const body = `
+    <h1>Tempo MCP — Setup</h1>
+    <p>Generate your personal MCP connector URL. Each field is the same value
+    you'd put in <code>.env</code> for the local CLI version. Credentials are
+    AES-GCM encrypted at rest in Cloudflare KV.</p>
+    ${e}
+    <form method="POST" action="/setup" class="card" autocomplete="off">
+      <h2>Tempo</h2>
+      <label for="tempoApiToken">Tempo API token <span class="req">*</span>
+        <span class="hint">Tempo → Settings → API Integration → New Token</span>
+      </label>
+      <input id="tempoApiToken" name="tempoApiToken" type="password" required value="${v('tempoApiToken')}">
+
+      <h2>Jira</h2>
+      <label for="jiraBaseUrl">Jira base URL <span class="req">*</span>
+        <span class="hint">e.g. <code>https://your-org.atlassian.net</code></span>
+      </label>
+      <input id="jiraBaseUrl" name="jiraBaseUrl" type="url" required placeholder="https://your-org.atlassian.net" value="${v('jiraBaseUrl')}">
+
+      <label>Jira authentication type</label>
+      <div class="row" style="gap:24px">
+        <label style="font-weight:400;display:inline-flex;align-items:center;gap:6px;margin:6px 0;">
+          <input type="radio" name="jiraAuthType" value="basic" ${checkedBasic}> Basic (email + token)
+        </label>
+        <label style="font-weight:400;display:inline-flex;align-items:center;gap:6px;margin:6px 0;color:var(--muted);" title="Atlassian scoped/OAuth access tokens require routing through api.atlassian.com/ex/jira/{cloudId}, which the remote server does not yet do — coming soon.">
+          <input type="radio" name="jiraAuthType" value="bearer" disabled> Bearer (OAuth access token) <span class="hint">— coming soon</span>
+        </label>
+      </div>
+
+      <label for="jiraApiToken">Jira API token <span class="req">*</span>
+        <span class="hint">Use a classic token from <code>id.atlassian.com</code>. (Scoped tokens are not supported yet.)</span>
+      </label>
+      <input id="jiraApiToken" name="jiraApiToken" type="password" required value="${v('jiraApiToken')}">
+
+      <div id="email-row">
+        <label for="jiraEmail">Jira email <span class="req">*</span>
+          <span class="hint">Required for Basic auth.</span>
+        </label>
+        <input id="jiraEmail" name="jiraEmail" type="email" placeholder="you@company.com" value="${v('jiraEmail')}">
+      </div>
+
+      <details>
+        <summary>Optional</summary>
+        <label for="jiraTempoAccountCustomFieldId">Tempo account custom field ID
+          <span class="hint">Only if your org uses Tempo's <em>Account</em> work attribute (numeric, e.g. <code>10234</code>)</span>
+        </label>
+        <input id="jiraTempoAccountCustomFieldId" name="jiraTempoAccountCustomFieldId" type="text" value="${v('jiraTempoAccountCustomFieldId')}">
+      </details>
+
+      <button type="submit">Generate MCP URL</button>
+    </form>
+
+    <div class="card">
+      <h2>What happens next</h2>
+      <ul>
+        <li>Server creates a unique URL like <code>/mcp/u_…</code>.</li>
+        <li>You paste that URL into Claude.ai → Settings → Connectors → Add custom connector.</li>
+        <li>Claude calls your URL with each tool invocation; the Worker decrypts your creds and proxies to Tempo + Jira.</li>
+        <li>Once added in Claude.ai web, the connector syncs to mobile (iOS/Android).</li>
+      </ul>
+    </div>
+  `;
+  return layout('Tempo MCP — Setup', body, SCRIPT_TOGGLE_AUTH);
+}
+
+export function renderSetupSuccess(mcpUrl: string): string {
+  const body = `
+    <h1>Your MCP URL</h1>
+    <div class="ok">Credentials saved. Copy the URL below and add it as a custom connector.</div>
+    <div class="card">
+      <h2>MCP URL</h2>
+      <div id="mcp-url" class="url-box">${escapeHtml(mcpUrl)}</div>
+      <button type="button" class="copy-btn" id="mcp-url-copy" onclick="copyUrl('mcp-url')">Copy URL</button>
+
+      <hr>
+
+      <div class="warn">
+        <strong>This URL is your credential.</strong> Anyone who has it can read and write
+        your Tempo worklogs. Treat it like a password: don't share, don't commit to git,
+        don't paste into chats.
+      </div>
+
+      <h2>Add to Claude.ai</h2>
+      <ul>
+        <li>Open <strong>Settings → Connectors</strong>.</li>
+        <li>Click <strong>Add custom connector</strong>.</li>
+        <li>Name it (e.g. "Tempo") and paste the URL above.</li>
+        <li>Click <strong>Add</strong>. Tools should appear within seconds.</li>
+      </ul>
+
+      <h2>Add to ChatGPT</h2>
+      <ul>
+        <li>Settings → Apps → Advanced → enable <strong>Developer mode</strong> (Pro/Plus/Business+).</li>
+        <li>New custom MCP server → paste the URL above.</li>
+        <li>Plus/Pro accounts can read; write tools require Business+.</li>
+      </ul>
+    </div>
+    <p style="margin-top:24px;text-align:center"><a href="/setup">← Generate another</a></p>
+  `;
+  return layout('Tempo MCP — Setup complete', body, SCRIPT_COPY);
+}
+
+type ParsedSetup =
+  | { ok: true; creds: UserCredentials }
+  | { ok: false; error: string; partial: Partial<UserCredentials> };
+
+async function parseFormData(request: Request): Promise<ParsedSetup> {
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return { ok: false, error: 'Could not parse form data.', partial: {} };
+  }
+  const get = (k: string) => {
+    const v = form.get(k);
+    return typeof v === 'string' ? v.trim() : '';
+  };
+  const partial: Partial<UserCredentials> = {
+    tempoApiToken: get('tempoApiToken'),
+    jiraBaseUrl: get('jiraBaseUrl'),
+    jiraApiToken: get('jiraApiToken'),
+    jiraEmail: get('jiraEmail') || undefined,
+    // Force basic. Bearer is wired through the type system and the storage
+    // layer for the day we add gateway-URL routing (see jira.ts), but until
+    // that's done a bearer config would 401 against the user's site URL.
+    // Ignore whatever the form sent.
+    jiraAuthType: 'basic',
+    jiraTempoAccountCustomFieldId:
+      get('jiraTempoAccountCustomFieldId') || undefined,
+  };
+
+  if (!partial.tempoApiToken)
+    return { ok: false, error: 'Tempo API token is required.', partial };
+  if (!partial.jiraBaseUrl)
+    return { ok: false, error: 'Jira base URL is required.', partial };
+  try {
+    const u = new URL(partial.jiraBaseUrl);
+    if (u.protocol !== 'https:') {
+      return {
+        ok: false,
+        error: 'Jira base URL must be an https URL.',
+        partial,
+      };
+    }
+  } catch {
+    return { ok: false, error: 'Jira base URL is not a valid URL.', partial };
+  }
+  if (!partial.jiraApiToken)
+    return { ok: false, error: 'Jira API token is required.', partial };
+  if (partial.jiraAuthType === 'basic' && !partial.jiraEmail) {
+    return {
+      ok: false,
+      error: 'Jira email is required for Basic auth.',
+      partial,
+    };
+  }
+  if (
+    partial.jiraTempoAccountCustomFieldId &&
+    !/^\d+$/.test(partial.jiraTempoAccountCustomFieldId)
+  ) {
+    return {
+      ok: false,
+      error: 'Tempo account custom field ID must be numeric.',
+      partial,
+    };
+  }
+  return { ok: true, creds: partial as UserCredentials };
+}
+
+export async function handleSetup(
+  request: Request,
+  env: StorageEnv,
+): Promise<Response> {
+  const baseUrl = new URL(request.url).origin;
+
+  if (request.method === 'GET') {
+    return new Response(renderSetupPage(), {
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  }
+  if (request.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  const parsed = await parseFormData(request);
+  if (!parsed.ok) {
+    return new Response(renderSetupPage(parsed.error, parsed.partial), {
+      status: 400,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  }
+
+  const userId = generateId('u');
+  await putCredentials(env, userId, parsed.creds);
+  const mcpUrl = `${baseUrl}/mcp/${userId}`;
+
+  return new Response(renderSetupSuccess(mcpUrl), {
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  });
+}
+
+export function renderLanding(): string {
+  const body = `
+    <h1>Tempo MCP Server</h1>
+    <p>Remote MCP server for managing Tempo worklogs in Jira. Use it from
+    Claude.ai (web + mobile) and ChatGPT (Developer Mode) without any local install.</p>
+    <div class="card">
+      <h2>Get started</h2>
+      <p>Click below to generate your personal MCP URL. You'll need a Tempo API token
+      and a classic Jira API token + email.</p>
+      <a href="/setup"><button type="button">Generate MCP URL</button></a>
+    </div>
+    <div class="card">
+      <h2>How it works</h2>
+      <ul>
+        <li>You enter your Tempo + Jira credentials once on the next page.</li>
+        <li>The server stores them encrypted (AES-GCM) and gives you a unique URL.</li>
+        <li>You paste that URL into Claude/ChatGPT as a custom connector.</li>
+        <li>The MCP tools (createWorklog, getWorklogAnalytics, etc.) work in any chat.</li>
+      </ul>
+    </div>
+  `;
+  return layout('Tempo MCP Server', body);
+}

--- a/src/remote/storage.ts
+++ b/src/remote/storage.ts
@@ -1,0 +1,138 @@
+/**
+ * Per-user credential storage for the remote MCP server.
+ *
+ * Layout in KV (`USERS` namespace):
+ *   user:<userId>           — AES-GCM(JSON of UserCredentials) base64
+ *
+ * Encryption is AES-GCM 256 with a fresh 12-byte IV per record. The key is
+ * derived once per Worker isolate from the `ENCRYPTION_KEY` Worker secret via
+ * SHA-256 — sufficient for a static secret of ≥32 high-entropy bytes.
+ *
+ * Note: rotating `ENCRYPTION_KEY` invalidates every existing user record (the
+ * AES-GCM tag won't validate), so users would need to re-run /setup. Treat
+ * the key as long-lived.
+ */
+
+export interface UserCredentials {
+  // Tempo
+  tempoApiToken: string;
+
+  // Jira
+  jiraBaseUrl: string;
+  jiraAuthType: 'basic' | 'bearer';
+  jiraApiToken: string;
+  /** Required for basic auth, ignored for bearer. */
+  jiraEmail?: string;
+  /** Optional Tempo account custom-field id (numeric, no `customfield_` prefix). */
+  jiraTempoAccountCustomFieldId?: string;
+}
+
+export interface StorageEnv {
+  USERS: KVNamespace;
+  ENCRYPTION_KEY: string;
+}
+
+const USER_PREFIX = 'user:';
+
+let cachedKey: CryptoKey | null = null;
+let cachedKeyMaterial: string | null = null;
+
+async function getKey(secret: string): Promise<CryptoKey> {
+  if (cachedKey && cachedKeyMaterial === secret) return cachedKey;
+  const raw = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(secret),
+  );
+  cachedKey = await crypto.subtle.importKey(
+    'raw',
+    raw,
+    { name: 'AES-GCM' },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+  cachedKeyMaterial = secret;
+  return cachedKey;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let s = '';
+  for (const byte of bytes) s += String.fromCharCode(byte);
+  return btoa(s);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const s = atob(b64);
+  const out = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
+  return out;
+}
+
+async function encrypt(plaintext: string, secret: string): Promise<string> {
+  const key = await getKey(secret);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ct = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+  // pack iv|ciphertext as a single base64 blob
+  const ctBytes = new Uint8Array(ct);
+  const merged = new Uint8Array(iv.length + ctBytes.length);
+  merged.set(iv, 0);
+  merged.set(ctBytes, iv.length);
+  return bytesToBase64(merged);
+}
+
+async function decrypt(blob: string, secret: string): Promise<string> {
+  const key = await getKey(secret);
+  const merged = base64ToBytes(blob);
+  const iv = merged.slice(0, 12);
+  const ct = merged.slice(12);
+  const pt = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct);
+  return new TextDecoder().decode(pt);
+}
+
+/**
+ * Generate an opaque user id: `u_` followed by 22 base64url chars (16 bytes
+ * → ~128 bits of entropy).
+ */
+export function generateId(prefix: 'u'): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  // base64url: + → -, / → _, strip =
+  const b64 = bytesToBase64(bytes)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `${prefix}_${b64}`;
+}
+
+export async function putCredentials(
+  env: StorageEnv,
+  userId: string,
+  creds: UserCredentials,
+): Promise<void> {
+  const blob = await encrypt(JSON.stringify(creds), env.ENCRYPTION_KEY);
+  await env.USERS.put(`${USER_PREFIX}${userId}`, blob);
+}
+
+export async function getCredentials(
+  env: StorageEnv,
+  userId: string,
+): Promise<UserCredentials | null> {
+  const blob = await env.USERS.get(`${USER_PREFIX}${userId}`);
+  if (!blob) return null;
+  try {
+    const json = await decrypt(blob, env.ENCRYPTION_KEY);
+    return JSON.parse(json) as UserCredentials;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate a user id matches the `u_<base64url>` shape we emit.
+ * Cheap rejection of obviously-malformed paths before a KV lookup.
+ */
+export function isValidId(id: string, prefix: 'u'): boolean {
+  return new RegExp(`^${prefix}_[A-Za-z0-9_-]{20,32}$`).test(id);
+}

--- a/src/remote/worker.ts
+++ b/src/remote/worker.ts
@@ -1,0 +1,149 @@
+/**
+ * Cloudflare Worker entrypoint — remote/multi-tenant Tempo MCP server.
+ *
+ * Routes:
+ *   GET  /                        Landing page with link to /setup.
+ *   GET  /setup                   Onboarding form (paste Tempo + Jira creds).
+ *   POST /setup                   Stores creds in KV; returns success page
+ *                                 with the user's MCP URL.
+ *   POST /mcp/u_<id>              Streamable HTTP MCP endpoint, scoped to
+ *                                 the user identified by `u_<id>` in the path.
+ *   GET  /mcp/u_<id>              Same endpoint (Streamable HTTP allows GET
+ *                                 for SSE upgrade and capability advertising).
+ *   *    /healthz                 Liveness probe.
+ *
+ * Auth model: the URL `/mcp/u_<id>` IS the credential. The 22-char base64url
+ * suffix carries ~128 bits of entropy. Anyone with the URL can act as the
+ * user. We never return 401 for this path — Claude.ai web has known bugs
+ * around the 401-then-OAuth flow. Returning 404 for unknown ids matches what
+ * Zapier MCP, Pipedream MCP, and other URL-token MCP servers do today.
+ */
+
+import { createMcpHandler } from 'agents/mcp';
+import { buildMcpServer } from './agent.js';
+import { getCredentials, isValidId, StorageEnv } from './storage.js';
+import { handleSetup, renderLanding } from './setup.js';
+
+interface Env extends StorageEnv {
+  ALLOWED_ORIGIN?: string;
+  /** Rate limit binding declared in wrangler.jsonc#ratelimits. */
+  SETUP_RATE_LIMITER: RateLimit;
+}
+
+const MCP_PATH_RE = /^\/mcp\/(u_[A-Za-z0-9_-]+)\/?$/;
+
+function corsHeaders(env: Env): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': env.ALLOWED_ORIGIN ?? '*',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers':
+      'Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version, Accept, Last-Event-ID',
+    // CRITICAL: browser MCP clients lose the session id without this — silent failure.
+    'Access-Control-Expose-Headers': 'Mcp-Session-Id, Mcp-Protocol-Version',
+    'Access-Control-Max-Age': '86400',
+  };
+}
+
+function withCors(response: Response, env: Env): Response {
+  const headers = new Headers(response.headers);
+  for (const [k, v] of Object.entries(corsHeaders(env))) headers.set(k, v);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export default {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders(env) });
+    }
+
+    if (url.pathname === '/healthz') {
+      return new Response('ok', {
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    }
+
+    if (url.pathname === '/' || url.pathname === '') {
+      return new Response(renderLanding(), {
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Referrer-Policy': 'no-referrer',
+        },
+      });
+    }
+
+    if (url.pathname === '/setup') {
+      // Per-IP rate limit on POST only. GET is a static form render and is
+      // safe to hammer; POST writes to KV and is the abuse target.
+      if (request.method === 'POST') {
+        const ip = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+        const { success } = await env.SETUP_RATE_LIMITER.limit({ key: ip });
+        if (!success) {
+          return new Response(
+            'Too many setup attempts. Try again in a minute.',
+            {
+              status: 429,
+              headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+            },
+          );
+        }
+      }
+      const response = await handleSetup(request, env);
+      // Re-wrap to add hardening headers. setup.ts already sets Content-Type.
+      // no-store: success page contains the MCP URL (= credential); the error
+      // re-render echoes submitted tokens back into password inputs. Neither
+      // should sit in any cache.
+      const headers = new Headers(response.headers);
+      headers.set('Referrer-Policy', 'no-referrer');
+      headers.set('Cache-Control', 'no-store');
+      return new Response(response.body, {
+        status: response.status,
+        headers,
+      });
+    }
+
+    const mcpMatch = url.pathname.match(MCP_PATH_RE);
+    if (mcpMatch) {
+      return withCors(await handleMcp(request, env, ctx, mcpMatch[1]), env);
+    }
+
+    return new Response('Not found', { status: 404 });
+  },
+};
+
+async function handleMcp(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  userId: string,
+): Promise<Response> {
+  if (!isValidId(userId, 'u')) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const creds = await getCredentials(env, userId);
+  if (!creds) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  // The handler matches `route: "/mcp"` exactly, so rewrite the URL before
+  // forwarding. The user-facing path stays /mcp/u_xxx; the inner request the
+  // SDK sees is /mcp.
+  const innerUrl = new URL(request.url);
+  innerUrl.pathname = '/mcp';
+  const innerRequest = new Request(innerUrl.toString(), request);
+
+  // MCP SDK ≥1.26 throws on McpServer reuse — build a fresh one per request.
+  const server = buildMcpServer(creds);
+  const handler = createMcpHandler(server, { route: '/mcp' });
+  return handler(innerRequest, env, ctx);
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -10,9 +10,9 @@ import {
   MissingWorklogDay,
   AnalyticsGroup,
   AnalyticsGroupBy,
+  Ctx,
 } from './types.js';
-import config from './config.js';
-import { getCurrentUserAccountId, getIssue } from './jira.js';
+import { createJiraClient, JiraClient } from './jira.js';
 import {
   formatError,
   getIssueInfoMap,
@@ -22,496 +22,830 @@ import {
   formatPercent,
 } from './utils.js';
 
-// API client for Tempo
-const api = axios.create({
-  baseURL: config.tempoApi.baseUrl,
-  headers: {
-    Authorization: `Bearer ${config.tempoApi.token}`,
-    'Content-Type': 'application/json',
-  },
-});
-
 // Tempo's /worklogs endpoints accept up to limit=1000 per page (sibling
-// endpoints cap at 5000; 1000 is the documented safe practical cap). Asking
-// for 1000 means a typical month-long query fits in a single round trip.
+// endpoints cap at 5000; 1000 is the documented safe practical cap).
 const TEMPO_PAGE_LIMIT = 1000;
 
 // Safety cap on total pages — protects against an infinite loop if Tempo's
 // `metadata.next` ever fails to terminate. At limit=1000 this is 500,000
 // worklogs / 100,000 schedule entries, well beyond any realistic query.
-// Hitting it throws (rather than silently truncating) so callers never get
-// misleadingly partial results.
 const MAX_PAGES = 500;
 
-/**
- * Fetch all worklogs for the current user across paginated pages.
- * Shared by retrieveWorklogs, getMissingWorklogDays, getWorklogAnalytics.
- */
-async function fetchAllWorklogs(
-  startDate: string,
-  endDate: string,
-): Promise<{ worklogs: any[]; pagesProcessed: number }> {
-  const accountId = await getCurrentUserAccountId();
-
-  let allWorklogs: any[] = [];
-  let nextUrl: string | null = null;
-  let isFirstRequest = true;
-  let pageCount = 0;
-
-  do {
-    if (pageCount >= MAX_PAGES) {
-      throw new Error(
-        `Reached maximum page limit (${MAX_PAGES}) while fetching worklogs ` +
-          `for ${startDate}..${endDate}. Results would be incomplete — ` +
-          `narrow the date range and try again.`,
-      );
-    }
-
-    let response;
-    if (isFirstRequest) {
-      response = await api.get(`/worklogs/user/${accountId}`, {
-        params: { from: startDate, to: endDate, limit: TEMPO_PAGE_LIMIT },
-      });
-      isFirstRequest = false;
-    } else {
-      response = await axios.get(nextUrl!, {
-        headers: {
-          Authorization: `Bearer ${config.tempoApi.token}`,
-          'Content-Type': 'application/json',
-        },
-      });
-    }
-
-    const pageWorklogs = response.data.results || [];
-    allWorklogs = allWorklogs.concat(pageWorklogs);
-
-    nextUrl = response.data.metadata?.next || null;
-    pageCount++;
-  } while (nextUrl);
-
-  return { worklogs: allWorklogs, pagesProcessed: pageCount };
+export interface Tools {
+  retrieveWorklogs(startDate: string, endDate: string): Promise<ToolResponse>;
+  createWorklog(
+    issueKey: string,
+    timeSpentHours: number,
+    date: string,
+    description?: string,
+    startTime?: string,
+    attributes?: WorkAttribute[],
+  ): Promise<ToolResponse>;
+  bulkCreateWorklogs(worklogEntries: WorklogEntry[]): Promise<ToolResponse>;
+  editWorklog(
+    worklogId: string,
+    timeSpentHours: number,
+    description?: string | null,
+    date?: string | null,
+    startTime?: string,
+    attributes?: WorkAttribute[],
+  ): Promise<ToolResponse>;
+  deleteWorklog(worklogId: string): Promise<ToolResponse>;
+  getMissingWorklogDays(
+    startDate: string,
+    endDate: string,
+    minHoursPerDay?: number,
+  ): Promise<ToolResponse>;
+  getWorklogAnalytics(
+    startDate: string,
+    endDate: string,
+    groupBy?: AnalyticsGroupBy,
+  ): Promise<ToolResponse>;
 }
 
-/**
- * Retrieve worklogs for the configured user within a date range
- */
-export async function retrieveWorklogs(
-  startDate: string,
-  endDate: string,
-): Promise<ToolResponse> {
-  try {
-    const { worklogs, pagesProcessed } = await fetchAllWorklogs(
-      startDate,
-      endDate,
-    );
+export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
+  const jiraClient = jira ?? createJiraClient(ctx);
 
-    // If no worklogs found, return empty content
-    if (worklogs.length === 0) {
+  // Tempo API tokens are static (no refresh) so a single Axios instance is fine.
+  const api = axios.create({
+    baseURL: ctx.tempoApi.baseUrl,
+    headers: {
+      Authorization: `Bearer ${ctx.tempoApi.token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  // Helper: paginated fetch from Tempo `metadata.next` URLs.
+  // Tempo's "next" URLs are absolute and don't include the bearer header —
+  // we re-attach it on each follow-up request.
+  async function fetchAllWorklogs(
+    startDate: string,
+    endDate: string,
+  ): Promise<{ worklogs: any[]; pagesProcessed: number }> {
+    const accountId = await jiraClient.getCurrentUserAccountId();
+
+    let allWorklogs: any[] = [];
+    let nextUrl: string | null = null;
+    let isFirstRequest = true;
+    let pageCount = 0;
+
+    do {
+      if (pageCount >= MAX_PAGES) {
+        throw new Error(
+          `Reached maximum page limit (${MAX_PAGES}) while fetching worklogs ` +
+            `for ${startDate}..${endDate}. Results would be incomplete — ` +
+            `narrow the date range and try again.`,
+        );
+      }
+
+      let response;
+      if (isFirstRequest) {
+        response = await api.get(`/worklogs/user/${accountId}`, {
+          params: { from: startDate, to: endDate, limit: TEMPO_PAGE_LIMIT },
+        });
+        isFirstRequest = false;
+      } else {
+        response = await axios.get(nextUrl!, {
+          headers: {
+            Authorization: `Bearer ${ctx.tempoApi.token}`,
+            'Content-Type': 'application/json',
+          },
+        });
+      }
+
+      const pageWorklogs = response.data.results || [];
+      allWorklogs = allWorklogs.concat(pageWorklogs);
+
+      nextUrl = response.data.metadata?.next || null;
+      pageCount++;
+    } while (nextUrl);
+
+    return { worklogs: allWorklogs, pagesProcessed: pageCount };
+  }
+
+  async function fetchTempoAccountFromIssue({
+    tempoAccountId,
+  }: {
+    tempoAccountId?: string;
+  }) {
+    return tempoAccountId ? await retrieveAccount(tempoAccountId) : undefined;
+  }
+
+  async function retrieveAccount(
+    id: string,
+  ): Promise<{ key: string; name: string }> {
+    const response = await api.get(`/accounts/${id}`);
+    return response.data;
+  }
+
+  async function fetchUserSchedule(
+    accountId: string,
+    startDate: string,
+    endDate: string,
+  ): Promise<DaySchedule[]> {
+    let allDays: DaySchedule[] = [];
+    let nextUrl: string | null = null;
+    let isFirstRequest = true;
+    let pageCount = 0;
+
+    try {
+      do {
+        if (pageCount >= MAX_PAGES) {
+          throw new Error(
+            `Reached maximum page limit (${MAX_PAGES}) while fetching user ` +
+              `schedule for ${startDate}..${endDate}. Results would be ` +
+              `incomplete — narrow the date range and try again.`,
+          );
+        }
+
+        let response;
+        if (isFirstRequest) {
+          response = await api.get(`/user-schedule/${accountId}`, {
+            params: { from: startDate, to: endDate, limit: TEMPO_PAGE_LIMIT },
+          });
+          isFirstRequest = false;
+        } else {
+          response = await axios.get(nextUrl!, {
+            headers: {
+              Authorization: `Bearer ${ctx.tempoApi.token}`,
+              'Content-Type': 'application/json',
+            },
+          });
+        }
+
+        const days: DaySchedule[] = Array.isArray(response.data)
+          ? response.data
+          : response.data.results || [];
+        allDays = allDays.concat(days);
+
+        nextUrl = Array.isArray(response.data)
+          ? null
+          : response.data.metadata?.next || null;
+        pageCount++;
+      } while (nextUrl);
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 403) {
+        throw new Error(
+          'Tempo API returned 403 for /user-schedule. Your TEMPO_API_TOKEN ' +
+            'is missing the "Schemes" scope (which covers Workload Schemes, ' +
+            'Holiday Schemes, and User Schedule). Tempo does not allow ' +
+            'modifying scopes on an existing token — create a new token at ' +
+            'Tempo > Settings > API Integration with both "Worklogs" and ' +
+            '"Schemes" scopes, then update TEMPO_API_TOKEN.',
+        );
+      }
+      throw error;
+    }
+
+    return allDays;
+  }
+
+  function validateDateRange(
+    startDate: string,
+    endDate: string,
+  ): ToolResponse | null {
+    if (startDate > endDate) {
       return {
+        isError: true,
         content: [
           {
             type: 'text',
-            text: 'No worklogs found for the specified date range.',
+            text: `Invalid range: startDate (${startDate}) must be on or before endDate (${endDate}).`,
           },
         ],
       };
     }
-
-    // Get issue keys for all worklogs
-    const issueInfoMap = await getIssueInfoMap(
-      extractWorklogIssueIds(worklogs),
-    );
-
-    // Format the response
-    const formattedContent = worklogs.map((worklog: any) => {
-      const tempoWorklogId = worklog.tempoWorklogId || 'Unknown';
-      const issueId = worklog.issue?.id || 'Unknown';
-      const issueKey = issueInfoMap[issueId]?.key || 'Unknown';
-      const description = worklog.description || 'No description';
-      const timeSpentHours = (worklog.timeSpentSeconds / 3600).toFixed(2);
-      const date = worklog.startDate || 'Unknown';
-      const startTime = worklog.startTime || '';
-      const attributeValues = worklog.attributes?.values;
-      const attributesInfo = attributeValues?.length
-        ? ` | Attributes: ${JSON.stringify(attributeValues)}`
-        : '';
-
-      return {
-        type: 'text' as const,
-        text: `TempoWorklogId: ${tempoWorklogId} | IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date}${startTime ? ` | StartTime: ${startTime}` : ''} | Hours: ${timeSpentHours} | Description: ${description}${attributesInfo}`,
-      };
-    });
-
-    return {
-      content: formattedContent,
-      metadata: {
-        totalCount: worklogs.length,
-        pagesProcessed,
-        startDate,
-        endDate,
-      },
-    };
-  } catch (error) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: `Error retrieving worklogs: ${formatError(error)}`,
-        },
-      ],
-    };
+    return null;
   }
-}
 
-/**
- * Create a new worklog
- */
-export async function createWorklog(
-  issueKey: string,
-  timeSpentHours: number,
-  date: string,
-  description: string = '',
-  startTime: string | undefined = undefined,
-  attributes?: WorkAttribute[],
-): Promise<ToolResponse> {
-  try {
-    // Get issue ID and account ID
-    const issue = await getIssue(issueKey);
-    const accountId = await getCurrentUserAccountId();
-
-    const account = await fetchTempoAccountFromIssue(issue);
-
-    const { id: issueId } = issue;
-    // Prepare attributes array (auto-detected _Account_ takes precedence)
-    const attributesArray = mergeAttributes(account, attributes);
-    // Prepare payload
-    const payload = {
-      issueId: Number(issueId),
-      timeSpentSeconds: Math.round(timeSpentHours * 3600),
-      startDate: date,
-      authorAccountId: accountId,
-      description,
-      ...(startTime && { startTime: `${startTime}:00` }),
-      ...(attributesArray.length > 0 && { attributes: attributesArray }),
-    };
-
-    // Submit the worklog
-    const response = await api.post('/worklogs', payload);
-
-    // Calculate end time if start time is provided
-    let timeInfo = '';
-    if (startTime) {
-      const endTime = calculateEndTime(startTime, timeSpentHours);
-      timeInfo = ` starting at ${startTime} and ending at ${endTime}`;
-    }
-
-    const accountInfo = account ? ` with account '${account.name}'` : '';
-    const userAttrInfo =
-      attributes && attributes.length > 0
-        ? ` with attributes: ${attributes.map((a) => `${a.key}=${a.value}`).join(', ')}`
-        : '';
-
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Worklog with ID ${response.data.tempoWorklogId} created successfully for ${issueKey}${accountInfo}${userAttrInfo}. Time logged: ${timeSpentHours} hours on ${date}${timeInfo}`,
-        },
-      ],
-    };
-  } catch (error) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: `Failed to create worklog: ${formatError(error)}`,
-        },
-      ],
-    };
-  }
-}
-
-/**
- * Create multiple worklogs
- */
-export async function bulkCreateWorklogs(
-  worklogEntries: WorklogEntry[],
-): Promise<ToolResponse> {
-  try {
-    // Get user account ID
-    const authorAccountId = await getCurrentUserAccountId();
-
-    // Group entries by issue key
-    const entriesByIssueKey: Record<string, WorklogEntry[]> = {};
-    worklogEntries.forEach((entry) => {
-      if (!entriesByIssueKey[entry.issueKey]) {
-        entriesByIssueKey[entry.issueKey] = [];
-      }
-      entriesByIssueKey[entry.issueKey].push(entry);
-    });
-
-    const results: WorklogResult[] = [];
-    const errors: WorklogError[] = [];
-
-    // Process each issue's entries
-    for (const [issueKey, entries] of Object.entries(entriesByIssueKey)) {
+  return {
+    async retrieveWorklogs(
+      startDate: string,
+      endDate: string,
+    ): Promise<ToolResponse> {
       try {
-        const issue = await getIssue(issueKey);
+        const { worklogs, pagesProcessed } = await fetchAllWorklogs(
+          startDate,
+          endDate,
+        );
 
-        const account = await fetchTempoAccountFromIssue(issue);
-
-        // Format entries for API
-        const formattedEntries = entries.map((entry) => {
-          const attributesArray = mergeAttributes(account, entry.attributes);
+        if (worklogs.length === 0) {
           return {
-            timeSpentSeconds: Math.round(entry.timeSpentHours * 3600),
-            startDate: entry.date,
-            authorAccountId,
-            description: entry.description || '',
-            ...(entry.startTime && { startTime: `${entry.startTime}:00` }),
-            ...(attributesArray.length > 0 && { attributes: attributesArray }),
+            content: [
+              {
+                type: 'text',
+                text: 'No worklogs found for the specified date range.',
+              },
+            ],
+          };
+        }
+
+        const issueInfoMap = await getIssueInfoMap(
+          jiraClient,
+          extractWorklogIssueIds(worklogs),
+        );
+
+        const formattedContent = worklogs.map((worklog: any) => {
+          const tempoWorklogId = worklog.tempoWorklogId || 'Unknown';
+          const issueId = worklog.issue?.id || 'Unknown';
+          const issueKey = issueInfoMap[issueId]?.key || 'Unknown';
+          const description = worklog.description || 'No description';
+          const timeSpentHours = (worklog.timeSpentSeconds / 3600).toFixed(2);
+          const date = worklog.startDate || 'Unknown';
+          const startTime = worklog.startTime || '';
+          const attributeValues = worklog.attributes?.values;
+          const attributesInfo = attributeValues?.length
+            ? ` | Attributes: ${JSON.stringify(attributeValues)}`
+            : '';
+
+          return {
+            type: 'text' as const,
+            text: `TempoWorklogId: ${tempoWorklogId} | IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date}${startTime ? ` | StartTime: ${startTime}` : ''} | Hours: ${timeSpentHours} | Description: ${description}${attributesInfo}`,
           };
         });
 
-        const { id: issueId } = issue;
-
-        // Submit bulk request
-        const response = await api.post(
-          `/worklogs/issue/${Number(issueId)}/bulk`,
-          formattedEntries,
-        );
-        const createdWorklogs = response.data || [];
-
-        // Record results
-        entries.forEach((entry, i) => {
-          const created = createdWorklogs[i] || null;
-
-          // Calculate end time if startTime is provided
-          let endTime = undefined;
-          if (entry.startTime && created) {
-            endTime = calculateEndTime(entry.startTime, entry.timeSpentHours);
-          }
-
-          results.push({
-            issueKey,
-            timeSpentHours: entry.timeSpentHours,
-            date: entry.date,
-            worklogId: created?.tempoWorklogId || null,
-            success: !!created,
-            startTime: entry.startTime,
-            endTime,
-            account: account?.name,
-          });
-        });
+        return {
+          content: formattedContent,
+          metadata: {
+            totalCount: worklogs.length,
+            pagesProcessed,
+            startDate,
+            endDate,
+          },
+        };
       } catch (error) {
-        const errorMessage = formatError(error);
-
-        // Record errors
-        entries.forEach((entry) => {
-          errors.push({
-            issueKey,
-            timeSpentHours: entry.timeSpentHours,
-            date: entry.date,
-            error: errorMessage,
-          });
-        });
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Error retrieving worklogs: ${formatError(error)}`,
+            },
+          ],
+        };
       }
-    }
+    },
 
-    // Create content for response
-    const content: Array<{ type: 'text'; text: string }> = [];
-    const successCount = results.filter((r) => r.success).length;
+    async createWorklog(
+      issueKey: string,
+      timeSpentHours: number,
+      date: string,
+      description: string = '',
+      startTime: string | undefined = undefined,
+      attributes?: WorkAttribute[],
+    ): Promise<ToolResponse> {
+      try {
+        const issue = await jiraClient.getIssue(issueKey);
+        const accountId = await jiraClient.getCurrentUserAccountId();
 
-    // Add success messages
-    if (successCount > 0) {
-      content.push({
-        type: 'text',
-        text: `Successfully created ${successCount} worklogs:`,
-      });
+        const account = await fetchTempoAccountFromIssue(issue);
 
-      results
-        .filter((r) => r.success)
-        .forEach((result) => {
-          let timeInfo = '';
-          if (result.startTime) {
-            timeInfo = ` starting at ${result.startTime}${result.endTime ? ` and ending at ${result.endTime}` : ''}`;
-          }
+        const { id: issueId } = issue;
+        const attributesArray = mergeAttributes(account, attributes);
+        const payload = {
+          issueId: Number(issueId),
+          timeSpentSeconds: Math.round(timeSpentHours * 3600),
+          startDate: date,
+          authorAccountId: accountId,
+          description,
+          ...(startTime && { startTime: `${startTime}:00` }),
+          ...(attributesArray.length > 0 && { attributes: attributesArray }),
+        };
 
-          const accountInfo = result.account
-            ? ` for account '${result.account}'`
+        const response = await api.post('/worklogs', payload);
+
+        let timeInfo = '';
+        if (startTime) {
+          const endTime = calculateEndTime(startTime, timeSpentHours);
+          timeInfo = ` starting at ${startTime} and ending at ${endTime}`;
+        }
+
+        const accountInfo = account ? ` with account '${account.name}'` : '';
+        const userAttrInfo =
+          attributes && attributes.length > 0
+            ? ` with attributes: ${attributes.map((a) => `${a.key}=${a.value}`).join(', ')}`
             : '';
 
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Worklog with ID ${response.data.tempoWorklogId} created successfully for ${issueKey}${accountInfo}${userAttrInfo}. Time logged: ${timeSpentHours} hours on ${date}${timeInfo}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Failed to create worklog: ${formatError(error)}`,
+            },
+          ],
+        };
+      }
+    },
+
+    async bulkCreateWorklogs(
+      worklogEntries: WorklogEntry[],
+    ): Promise<ToolResponse> {
+      try {
+        const authorAccountId = await jiraClient.getCurrentUserAccountId();
+
+        const entriesByIssueKey: Record<string, WorklogEntry[]> = {};
+        worklogEntries.forEach((entry) => {
+          if (!entriesByIssueKey[entry.issueKey]) {
+            entriesByIssueKey[entry.issueKey] = [];
+          }
+          entriesByIssueKey[entry.issueKey].push(entry);
+        });
+
+        const results: WorklogResult[] = [];
+        const errors: WorklogError[] = [];
+
+        for (const [issueKey, entries] of Object.entries(entriesByIssueKey)) {
+          try {
+            const issue = await jiraClient.getIssue(issueKey);
+
+            const account = await fetchTempoAccountFromIssue(issue);
+
+            const formattedEntries = entries.map((entry) => {
+              const attributesArray = mergeAttributes(
+                account,
+                entry.attributes,
+              );
+              return {
+                timeSpentSeconds: Math.round(entry.timeSpentHours * 3600),
+                startDate: entry.date,
+                authorAccountId,
+                description: entry.description || '',
+                ...(entry.startTime && { startTime: `${entry.startTime}:00` }),
+                ...(attributesArray.length > 0 && {
+                  attributes: attributesArray,
+                }),
+              };
+            });
+
+            const { id: issueId } = issue;
+
+            const response = await api.post(
+              `/worklogs/issue/${Number(issueId)}/bulk`,
+              formattedEntries,
+            );
+            const createdWorklogs = response.data || [];
+
+            entries.forEach((entry, i) => {
+              const created = createdWorklogs[i] || null;
+
+              let endTime = undefined;
+              if (entry.startTime && created) {
+                endTime = calculateEndTime(
+                  entry.startTime,
+                  entry.timeSpentHours,
+                );
+              }
+
+              results.push({
+                issueKey,
+                timeSpentHours: entry.timeSpentHours,
+                date: entry.date,
+                worklogId: created?.tempoWorklogId || null,
+                success: !!created,
+                startTime: entry.startTime,
+                endTime,
+                account: account?.name,
+              });
+            });
+          } catch (error) {
+            const errorMessage = formatError(error);
+
+            entries.forEach((entry) => {
+              errors.push({
+                issueKey,
+                timeSpentHours: entry.timeSpentHours,
+                date: entry.date,
+                error: errorMessage,
+              });
+            });
+          }
+        }
+
+        const content: Array<{ type: 'text'; text: string }> = [];
+        const successCount = results.filter((r) => r.success).length;
+
+        if (successCount > 0) {
           content.push({
             type: 'text',
-            text: `- Issue ${result.issueKey}: ${result.timeSpentHours} hours on ${result.date}${timeInfo}${accountInfo}`,
+            text: `Successfully created ${successCount} worklogs:`,
           });
-        });
-    }
 
-    // Add error messages
-    if (errors.length > 0) {
-      content.push({
-        type: 'text',
-        text: `Failed to create ${errors.length} worklogs:`,
-      });
+          results
+            .filter((r) => r.success)
+            .forEach((result) => {
+              let timeInfo = '';
+              if (result.startTime) {
+                timeInfo = ` starting at ${result.startTime}${result.endTime ? ` and ending at ${result.endTime}` : ''}`;
+              }
 
-      errors.forEach((error) => {
-        content.push({
-          type: 'text',
-          text: `- Issue ${error.issueKey}: ${error.timeSpentHours} hours on ${error.date}. Error: ${error.error}`,
-        });
-      });
-    }
+              const accountInfo = result.account
+                ? ` for account '${result.account}'`
+                : '';
 
-    return {
-      content,
-      metadata: {
-        totalSuccess: successCount,
-        totalFailure: errors.length,
-        details: {
-          successes: results.filter((r) => r.success),
-          failures: errors,
-        },
-      },
-      isError: errors.length > 0 && successCount === 0,
-    };
-  } catch (error) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: `Error processing bulk worklogs: ${formatError(error)}`,
-        },
-      ],
-    };
-  }
-}
+              content.push({
+                type: 'text',
+                text: `- Issue ${result.issueKey}: ${result.timeSpentHours} hours on ${result.date}${timeInfo}${accountInfo}`,
+              });
+            });
+        }
 
-/**
- * Edit an existing worklog
- */
-export async function editWorklog(
-  worklogId: string,
-  timeSpentHours: number,
-  description: string | null = null,
-  date: string | null = null,
-  startTime: string | undefined = undefined,
-  attributes?: WorkAttribute[],
-): Promise<ToolResponse> {
-  try {
-    // Get current worklog
-    const response = await api.get<TempoWorklog>(`/worklogs/${worklogId}`);
-    const worklog = response.data;
+        if (errors.length > 0) {
+          content.push({
+            type: 'text',
+            text: `Failed to create ${errors.length} worklogs:`,
+          });
 
-    // Extract existing attributes from the worklog and merge with user-provided ones
-    const existingAttributes: WorkAttribute[] = (
-      worklog.attributes?.values || []
-    ).map((attr) => ({ key: attr.key, value: attr.value }));
-    const mergedAttributes = mergeExistingWithUserAttributes(
-      existingAttributes,
-      attributes,
-    );
+          errors.forEach((error) => {
+            content.push({
+              type: 'text',
+              text: `- Issue ${error.issueKey}: ${error.timeSpentHours} hours on ${error.date}. Error: ${error.error}`,
+            });
+          });
+        }
 
-    // Prepare update payload
-    const updatePayload = {
-      authorAccountId: worklog.author.accountId,
-      startDate: date || worklog.startDate,
-      timeSpentSeconds: Math.round(timeSpentHours * 3600),
-      billableSeconds: Math.round(timeSpentHours * 3600),
-      ...(description !== null && { description }),
-      ...(startTime && { startTime: `${startTime}:00` }),
-      ...(mergedAttributes.length > 0 && { attributes: mergedAttributes }),
-    };
+        return {
+          content,
+          metadata: {
+            totalSuccess: successCount,
+            totalFailure: errors.length,
+            details: {
+              successes: results.filter((r) => r.success),
+              failures: errors,
+            },
+          },
+          isError: errors.length > 0 && successCount === 0,
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Error processing bulk worklogs: ${formatError(error)}`,
+            },
+          ],
+        };
+      }
+    },
 
-    // Update the worklog
-    await api.put(`/worklogs/${worklogId}`, updatePayload);
+    async editWorklog(
+      worklogId: string,
+      timeSpentHours: number,
+      description: string | null = null,
+      date: string | null = null,
+      startTime: string | undefined = undefined,
+      attributes?: WorkAttribute[],
+    ): Promise<ToolResponse> {
+      try {
+        const response = await api.get<TempoWorklog>(`/worklogs/${worklogId}`);
+        const worklog = response.data;
 
-    // Information about the update
-    let updateInfo = `Worklog updated successfully`;
+        const existingAttributes: WorkAttribute[] = (
+          worklog.attributes?.values || []
+        ).map((attr) => ({ key: attr.key, value: attr.value }));
+        const mergedAttributes = mergeExistingWithUserAttributes(
+          existingAttributes,
+          attributes,
+        );
 
-    // Calculate and show time info if we have a start time
-    if (startTime) {
-      const endTime = calculateEndTime(startTime, timeSpentHours);
-      updateInfo += `. Time logged: ${timeSpentHours} hours starting at ${startTime} and ending at ${endTime}`;
-    }
+        const updatePayload = {
+          authorAccountId: worklog.author.accountId,
+          startDate: date || worklog.startDate,
+          timeSpentSeconds: Math.round(timeSpentHours * 3600),
+          billableSeconds: Math.round(timeSpentHours * 3600),
+          ...(description !== null && { description }),
+          ...(startTime && { startTime: `${startTime}:00` }),
+          ...(mergedAttributes.length > 0 && { attributes: mergedAttributes }),
+        };
 
-    // Format response
-    return {
-      content: [
-        {
-          type: 'text',
-          text: updateInfo,
-        },
-      ],
-    };
-  } catch (error) {
-    return {
-      isError: true,
-      content: [
-        { type: 'text', text: `Failed to edit worklog: ${formatError(error)}` },
-      ],
-    };
-  }
-}
+        await api.put(`/worklogs/${worklogId}`, updatePayload);
 
-/**
- * Delete a worklog
- */
-export async function deleteWorklog(worklogId: string): Promise<ToolResponse> {
-  try {
-    // Get worklog details for the response
-    let worklogDetails = null;
-    try {
-      const response = await api.get<TempoWorklog>(`/worklogs/${worklogId}`);
-      worklogDetails = response.data;
-    } catch (error) {
-      // Continue with deletion even if we can't get details
-      console.error(
-        `Could not fetch worklog details: ${(error as Error).message}`,
-      );
-    }
+        let updateInfo = `Worklog updated successfully`;
 
-    // Delete the worklog
-    await api.delete(`/worklogs/${worklogId}`);
+        if (startTime) {
+          const endTime = calculateEndTime(startTime, timeSpentHours);
+          updateInfo += `. Time logged: ${timeSpentHours} hours starting at ${startTime} and ending at ${endTime}`;
+        }
 
-    return {
-      content: [{ type: 'text', text: 'Worklog deleted successfully' }],
-    };
-  } catch (error) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: `Failed to delete worklog: ${formatError(error)}`,
-        },
-      ],
-    };
-  }
-}
+        return {
+          content: [{ type: 'text', text: updateInfo }],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Failed to edit worklog: ${formatError(error)}`,
+            },
+          ],
+        };
+      }
+    },
 
-/**
- *  @returns The tempo account that is associated with the issue, if any
- */
-async function fetchTempoAccountFromIssue({
-  tempoAccountId,
-}: {
-  tempoAccountId?: string;
-}) {
-  return tempoAccountId ? await retrieveAccount(tempoAccountId) : undefined;
-}
+    async deleteWorklog(worklogId: string): Promise<ToolResponse> {
+      try {
+        try {
+          await api.get<TempoWorklog>(`/worklogs/${worklogId}`);
+        } catch (error) {
+          console.error(
+            `Could not fetch worklog details: ${(error as Error).message}`,
+          );
+        }
 
-/**
- * Retrieve account details by ID
- */
-async function retrieveAccount(
-  id: string,
-): Promise<{ key: string; name: string }> {
-  const response = await api.get(`/accounts/${id}`);
-  return response.data;
+        await api.delete(`/worklogs/${worklogId}`);
+
+        return {
+          content: [{ type: 'text', text: 'Worklog deleted successfully' }],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Failed to delete worklog: ${formatError(error)}`,
+            },
+          ],
+        };
+      }
+    },
+
+    async getMissingWorklogDays(
+      startDate: string,
+      endDate: string,
+      minHoursPerDay?: number,
+    ): Promise<ToolResponse> {
+      const rangeError = validateDateRange(startDate, endDate);
+      if (rangeError) return rangeError;
+
+      try {
+        const accountId = await jiraClient.getCurrentUserAccountId();
+
+        const [schedule, { worklogs }] = await Promise.all([
+          fetchUserSchedule(accountId, startDate, endDate),
+          fetchAllWorklogs(startDate, endDate),
+        ]);
+
+        if (schedule.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `No user-schedule entries returned by Tempo for ${startDate} to ${endDate}. The user may not have a workload scheme configured for this period.`,
+              },
+            ],
+            metadata: {
+              totalMissingDays: 0,
+              totalMissingHours: 0,
+              startDate,
+              endDate,
+            },
+          };
+        }
+
+        const loggedByDate = new Map<string, Map<string, number>>();
+        for (const w of worklogs) {
+          const date = w.startDate;
+          if (!date) continue;
+          const issueId = w.issue?.id ? String(w.issue.id) : 'unknown';
+          const issueMap = loggedByDate.get(date) ?? new Map<string, number>();
+          issueMap.set(
+            issueId,
+            (issueMap.get(issueId) ?? 0) + Number(w.timeSpentSeconds ?? 0),
+          );
+          loggedByDate.set(date, issueMap);
+        }
+
+        const overrideSeconds =
+          minHoursPerDay !== undefined
+            ? Math.round(minHoursPerDay * 3600)
+            : null;
+
+        const missing: MissingWorklogDay[] = [];
+        for (const day of schedule) {
+          if (day.requiredSeconds <= 0) continue;
+
+          const requiredSeconds = overrideSeconds ?? day.requiredSeconds;
+          const dayIssues = loggedByDate.get(day.date);
+          const loggedSeconds = dayIssues
+            ? Array.from(dayIssues.values()).reduce((s, v) => s + v, 0)
+            : 0;
+          if (loggedSeconds >= requiredSeconds) continue;
+
+          const breakdown = dayIssues
+            ? Array.from(dayIssues.entries()).map(([issueId, seconds]) => ({
+                issueId,
+                hours: seconds / 3600,
+              }))
+            : [];
+
+          missing.push({
+            date: day.date,
+            type: day.type,
+            expectedHours: requiredSeconds / 3600,
+            loggedHours: loggedSeconds / 3600,
+            missingHours: (requiredSeconds - loggedSeconds) / 3600,
+            ...(day.holiday?.name ? { holiday: day.holiday.name } : {}),
+            ...(breakdown.length > 0 ? { loggedBreakdown: breakdown } : {}),
+          });
+        }
+
+        const partialIssueIds = new Set<string>();
+        for (const m of missing) {
+          for (const b of m.loggedBreakdown ?? []) {
+            if (b.issueId !== 'unknown') partialIssueIds.add(b.issueId);
+          }
+        }
+        const issueInfoMap =
+          partialIssueIds.size > 0
+            ? await getIssueInfoMap(jiraClient, Array.from(partialIssueIds))
+            : {};
+
+        if (missing.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `All working days between ${startDate} and ${endDate} meet the expected hours.`,
+              },
+            ],
+            metadata: {
+              totalMissingDays: 0,
+              totalMissingHours: 0,
+              startDate,
+              endDate,
+            },
+          };
+        }
+
+        const totalMissingHours = missing.reduce(
+          (sum, d) => sum + d.missingHours,
+          0,
+        );
+
+        const dayWord = missing.length === 1 ? 'day' : 'days';
+        const lines: string[] = [
+          `Found ${missing.length} ${dayWord} with missing worklogs · ${startDate} to ${endDate}`,
+          `Total missing: ${formatHours(totalMissingHours)}`,
+          '',
+        ];
+        for (const d of missing) {
+          const typeBadge = d.type === 'WORKING_DAY' ? '' : ` [${d.type}]`;
+          const holidayBadge = d.holiday ? ` (${d.holiday})` : '';
+          lines.push(
+            `${d.date}${typeBadge}${holidayBadge} — missing ${formatHours(d.missingHours)} (${formatHours(d.loggedHours)} of ${formatHours(d.expectedHours)} logged)`,
+          );
+          for (const b of d.loggedBreakdown ?? []) {
+            const info = issueInfoMap[b.issueId];
+            const label = info
+              ? info.summary
+                ? `${info.key} — ${info.summary}`
+                : info.key
+              : b.issueId === 'unknown'
+                ? 'Unknown issue'
+                : `Issue ${b.issueId}`;
+            lines.push(`    ${label}: ${formatHours(b.hours)}`);
+          }
+        }
+
+        return {
+          content: [{ type: 'text', text: lines.join('\n') }],
+          metadata: {
+            totalMissingDays: missing.length,
+            totalMissingHours,
+            startDate,
+            endDate,
+            details: missing,
+          },
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Failed to get missing worklog days: ${formatError(error)}`,
+            },
+          ],
+        };
+      }
+    },
+
+    async getWorklogAnalytics(
+      startDate: string,
+      endDate: string,
+      groupBy: AnalyticsGroupBy = 'issue',
+    ): Promise<ToolResponse> {
+      const rangeError = validateDateRange(startDate, endDate);
+      if (rangeError) return rangeError;
+
+      try {
+        const { worklogs } = await fetchAllWorklogs(startDate, endDate);
+
+        if (worklogs.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `No worklogs found between ${startDate} and ${endDate}.`,
+              },
+            ],
+            metadata: {
+              totalHours: 0,
+              totalWorklogs: 0,
+              groupBy,
+              startDate,
+              endDate,
+            },
+          };
+        }
+
+        let issueInfoMap: Record<string, { key: string; summary: string }> = {};
+        if (groupBy === 'issue') {
+          issueInfoMap = await getIssueInfoMap(
+            jiraClient,
+            extractWorklogIssueIds(worklogs),
+          );
+        }
+
+        const buckets = new Map<string, { seconds: number; count: number }>();
+        for (const w of worklogs) {
+          const key = computeGroupKey(w, groupBy, issueInfoMap);
+          const bucket = buckets.get(key) ?? { seconds: 0, count: 0 };
+          bucket.seconds += Number(w.timeSpentSeconds ?? 0);
+          bucket.count += 1;
+          buckets.set(key, bucket);
+        }
+
+        const totalSeconds = Array.from(buckets.values()).reduce(
+          (s, b) => s + b.seconds,
+          0,
+        );
+        const totalHours = totalSeconds / 3600;
+
+        const groups: AnalyticsGroup[] = Array.from(buckets.entries())
+          .map(([key, b]) => ({
+            key,
+            hours: b.seconds / 3600,
+            worklogCount: b.count,
+            percentage: totalSeconds > 0 ? (b.seconds / totalSeconds) * 100 : 0,
+          }))
+          .sort((a, b) => b.hours - a.hours);
+
+        const worklogWord = worklogs.length === 1 ? 'worklog' : 'worklogs';
+        const groupWord = groups.length === 1 ? 'group' : 'groups';
+        const lines: string[] = [
+          `Worklog analytics · ${startDate} to ${endDate} · grouped by ${groupBy}`,
+          `Total: ${formatHours(totalHours)} across ${worklogs.length} ${worklogWord} in ${groups.length} ${groupWord}`,
+          '',
+        ];
+        for (const g of groups) {
+          const wlWord = g.worklogCount === 1 ? 'worklog' : 'worklogs';
+          const stats = `${formatHours(g.hours)} · ${formatPercent(g.percentage)} · ${g.worklogCount} ${wlWord}`;
+          if (groupBy === 'issue') {
+            lines.push(g.key);
+            lines.push(`    ${stats}`);
+          } else {
+            lines.push(`${g.key} · ${stats}`);
+          }
+        }
+
+        return {
+          content: [{ type: 'text', text: lines.join('\n') }],
+          metadata: {
+            totalHours,
+            totalWorklogs: worklogs.length,
+            groupCount: groups.length,
+            groupBy,
+            startDate,
+            endDate,
+            details: groups,
+          },
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Failed to get worklog analytics: ${formatError(error)}`,
+            },
+          ],
+        };
+      }
+    },
+  };
 }
 
 /**
@@ -543,7 +877,6 @@ export function mergeAttributes(
 
 /**
  * Merge existing worklog attributes with user-provided overrides.
- * Existing attributes are preserved; user-provided attributes override matching keys.
  */
 function mergeExistingWithUserAttributes(
   existingAttributes: WorkAttribute[],
@@ -562,380 +895,6 @@ function mergeExistingWithUserAttributes(
   }
 
   return Array.from(merged.entries()).map(([key, value]) => ({ key, value }));
-}
-
-/**
- * Fetch the user-schedule from Tempo for a date range.
- * Returns daily expected hours, working/non-working/holiday classification.
- * Handles both paginated wrapper and direct array responses.
- *
- * Requires the Tempo API token to include the "Schemes" scope (covers
- * Workload Schemes, Holiday Schemes, User Schedule). 403 is rewritten to
- * a clear scope-guidance message.
- */
-async function fetchUserSchedule(
-  accountId: string,
-  startDate: string,
-  endDate: string,
-): Promise<DaySchedule[]> {
-  let allDays: DaySchedule[] = [];
-  let nextUrl: string | null = null;
-  let isFirstRequest = true;
-  let pageCount = 0;
-
-  try {
-    do {
-      if (pageCount >= MAX_PAGES) {
-        throw new Error(
-          `Reached maximum page limit (${MAX_PAGES}) while fetching user ` +
-            `schedule for ${startDate}..${endDate}. Results would be ` +
-            `incomplete — narrow the date range and try again.`,
-        );
-      }
-
-      let response;
-      if (isFirstRequest) {
-        response = await api.get(`/user-schedule/${accountId}`, {
-          params: { from: startDate, to: endDate, limit: TEMPO_PAGE_LIMIT },
-        });
-        isFirstRequest = false;
-      } else {
-        response = await axios.get(nextUrl!, {
-          headers: {
-            Authorization: `Bearer ${config.tempoApi.token}`,
-            'Content-Type': 'application/json',
-          },
-        });
-      }
-
-      const days: DaySchedule[] = Array.isArray(response.data)
-        ? response.data
-        : response.data.results || [];
-      allDays = allDays.concat(days);
-
-      nextUrl = Array.isArray(response.data)
-        ? null
-        : response.data.metadata?.next || null;
-      pageCount++;
-    } while (nextUrl);
-  } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 403) {
-      throw new Error(
-        'Tempo API returned 403 for /user-schedule. Your TEMPO_API_TOKEN ' +
-          'is missing the "Schemes" scope (which covers Workload Schemes, ' +
-          'Holiday Schemes, and User Schedule). Tempo does not allow ' +
-          'modifying scopes on an existing token — create a new token at ' +
-          'Tempo > Settings > API Integration with both "Worklogs" and ' +
-          '"Schemes" scopes, then update TEMPO_API_TOKEN.',
-      );
-    }
-    throw error;
-  }
-
-  return allDays;
-}
-
-/**
- * Reject inverted date ranges with a clear MCP error response.
- * Returns null when the range is valid, or a ToolResponse to short-circuit.
- * Lexicographic comparison is sound for YYYY-MM-DD strings.
- */
-function validateDateRange(
-  startDate: string,
-  endDate: string,
-): ToolResponse | null {
-  if (startDate > endDate) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: `Invalid range: startDate (${startDate}) must be on or before endDate (${endDate}).`,
-        },
-      ],
-    };
-  }
-  return null;
-}
-
-/**
- * Find working days in a range where the user has logged less time than
- * Tempo expects (per user-schedule). Honours holidays / non-working days
- * automatically. minHoursPerDay overrides the per-day expected hours but
- * still skips non-working days.
- */
-export async function getMissingWorklogDays(
-  startDate: string,
-  endDate: string,
-  minHoursPerDay?: number,
-): Promise<ToolResponse> {
-  const rangeError = validateDateRange(startDate, endDate);
-  if (rangeError) return rangeError;
-
-  try {
-    const accountId = await getCurrentUserAccountId();
-
-    const [schedule, { worklogs }] = await Promise.all([
-      fetchUserSchedule(accountId, startDate, endDate),
-      fetchAllWorklogs(startDate, endDate),
-    ]);
-
-    if (schedule.length === 0) {
-      // Empty schedule is a legitimate state — user has no workload scheme
-      // configured for this period. Not an error, just nothing to report.
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `No user-schedule entries returned by Tempo for ${startDate} to ${endDate}. The user may not have a workload scheme configured for this period.`,
-          },
-        ],
-        metadata: {
-          totalMissingDays: 0,
-          totalMissingHours: 0,
-          startDate,
-          endDate,
-        },
-      };
-    }
-
-    // Group worklogs by date, then by issue ID, summing seconds.
-    // Used to (a) compute total logged per day and (b) show per-day
-    // breakdown of what was actually logged on partially-missing days.
-    const loggedByDate = new Map<string, Map<string, number>>();
-    for (const w of worklogs) {
-      const date = w.startDate;
-      if (!date) continue;
-      const issueId = w.issue?.id ? String(w.issue.id) : 'unknown';
-      const issueMap = loggedByDate.get(date) ?? new Map<string, number>();
-      issueMap.set(
-        issueId,
-        (issueMap.get(issueId) ?? 0) + Number(w.timeSpentSeconds ?? 0),
-      );
-      loggedByDate.set(date, issueMap);
-    }
-
-    const overrideSeconds =
-      minHoursPerDay !== undefined ? Math.round(minHoursPerDay * 3600) : null;
-
-    const missing: MissingWorklogDay[] = [];
-    for (const day of schedule) {
-      // Skip days Tempo classifies as non-working, regardless of override
-      if (day.requiredSeconds <= 0) continue;
-
-      const requiredSeconds = overrideSeconds ?? day.requiredSeconds;
-      const dayIssues = loggedByDate.get(day.date);
-      const loggedSeconds = dayIssues
-        ? Array.from(dayIssues.values()).reduce((s, v) => s + v, 0)
-        : 0;
-      if (loggedSeconds >= requiredSeconds) continue;
-
-      const breakdown = dayIssues
-        ? Array.from(dayIssues.entries()).map(([issueId, seconds]) => ({
-            issueId,
-            hours: seconds / 3600,
-          }))
-        : [];
-
-      missing.push({
-        date: day.date,
-        type: day.type,
-        expectedHours: requiredSeconds / 3600,
-        loggedHours: loggedSeconds / 3600,
-        missingHours: (requiredSeconds - loggedSeconds) / 3600,
-        ...(day.holiday?.name ? { holiday: day.holiday.name } : {}),
-        ...(breakdown.length > 0 ? { loggedBreakdown: breakdown } : {}),
-      });
-    }
-
-    // Resolve issue keys + summaries for everything that appears in
-    // partial-day breakdowns (skipped if no partial days).
-    const partialIssueIds = new Set<string>();
-    for (const m of missing) {
-      for (const b of m.loggedBreakdown ?? []) {
-        if (b.issueId !== 'unknown') partialIssueIds.add(b.issueId);
-      }
-    }
-    const issueInfoMap =
-      partialIssueIds.size > 0
-        ? await getIssueInfoMap(Array.from(partialIssueIds))
-        : {};
-
-    if (missing.length === 0) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `All working days between ${startDate} and ${endDate} meet the expected hours.`,
-          },
-        ],
-        metadata: {
-          totalMissingDays: 0,
-          totalMissingHours: 0,
-          startDate,
-          endDate,
-        },
-      };
-    }
-
-    const totalMissingHours = missing.reduce(
-      (sum, d) => sum + d.missingHours,
-      0,
-    );
-
-    const dayWord = missing.length === 1 ? 'day' : 'days';
-    const lines: string[] = [
-      `Found ${missing.length} ${dayWord} with missing worklogs · ${startDate} to ${endDate}`,
-      `Total missing: ${formatHours(totalMissingHours)}`,
-      '',
-    ];
-    for (const d of missing) {
-      const typeBadge = d.type === 'WORKING_DAY' ? '' : ` [${d.type}]`;
-      const holidayBadge = d.holiday ? ` (${d.holiday})` : '';
-      lines.push(
-        `${d.date}${typeBadge}${holidayBadge} — missing ${formatHours(d.missingHours)} (${formatHours(d.loggedHours)} of ${formatHours(d.expectedHours)} logged)`,
-      );
-      for (const b of d.loggedBreakdown ?? []) {
-        const info = issueInfoMap[b.issueId];
-        const label = info
-          ? info.summary
-            ? `${info.key} — ${info.summary}`
-            : info.key
-          : b.issueId === 'unknown'
-            ? 'Unknown issue'
-            : `Issue ${b.issueId}`;
-        lines.push(`    ${label}: ${formatHours(b.hours)}`);
-      }
-    }
-
-    return {
-      content: [{ type: 'text', text: lines.join('\n') }],
-      metadata: {
-        totalMissingDays: missing.length,
-        totalMissingHours,
-        startDate,
-        endDate,
-        details: missing,
-      },
-    };
-  } catch (error) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: `Failed to get missing worklog days: ${formatError(error)}`,
-        },
-      ],
-    };
-  }
-}
-
-/**
- * Aggregate worklogs in a date range by issue / account / day / week / month.
- * Returns hours, count, and percentage per group, sorted by hours desc.
- */
-export async function getWorklogAnalytics(
-  startDate: string,
-  endDate: string,
-  groupBy: AnalyticsGroupBy = 'issue',
-): Promise<ToolResponse> {
-  const rangeError = validateDateRange(startDate, endDate);
-  if (rangeError) return rangeError;
-
-  try {
-    const { worklogs } = await fetchAllWorklogs(startDate, endDate);
-
-    if (worklogs.length === 0) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `No worklogs found between ${startDate} and ${endDate}.`,
-          },
-        ],
-        metadata: {
-          totalHours: 0,
-          totalWorklogs: 0,
-          groupBy,
-          startDate,
-          endDate,
-        },
-      };
-    }
-
-    let issueInfoMap: Record<string, { key: string; summary: string }> = {};
-    if (groupBy === 'issue') {
-      issueInfoMap = await getIssueInfoMap(extractWorklogIssueIds(worklogs));
-    }
-
-    const buckets = new Map<string, { seconds: number; count: number }>();
-    for (const w of worklogs) {
-      const key = computeGroupKey(w, groupBy, issueInfoMap);
-      const bucket = buckets.get(key) ?? { seconds: 0, count: 0 };
-      bucket.seconds += Number(w.timeSpentSeconds ?? 0);
-      bucket.count += 1;
-      buckets.set(key, bucket);
-    }
-
-    const totalSeconds = Array.from(buckets.values()).reduce(
-      (s, b) => s + b.seconds,
-      0,
-    );
-    const totalHours = totalSeconds / 3600;
-
-    const groups: AnalyticsGroup[] = Array.from(buckets.entries())
-      .map(([key, b]) => ({
-        key,
-        hours: b.seconds / 3600,
-        worklogCount: b.count,
-        percentage: totalSeconds > 0 ? (b.seconds / totalSeconds) * 100 : 0,
-      }))
-      .sort((a, b) => b.hours - a.hours);
-
-    const worklogWord = worklogs.length === 1 ? 'worklog' : 'worklogs';
-    const groupWord = groups.length === 1 ? 'group' : 'groups';
-    const lines: string[] = [
-      `Worklog analytics · ${startDate} to ${endDate} · grouped by ${groupBy}`,
-      `Total: ${formatHours(totalHours)} across ${worklogs.length} ${worklogWord} in ${groups.length} ${groupWord}`,
-      '',
-    ];
-    for (const g of groups) {
-      const wlWord = g.worklogCount === 1 ? 'worklog' : 'worklogs';
-      const stats = `${formatHours(g.hours)} · ${formatPercent(g.percentage)} · ${g.worklogCount} ${wlWord}`;
-      if (groupBy === 'issue') {
-        // Two-line: key + summary on one, stats indented below
-        lines.push(g.key);
-        lines.push(`    ${stats}`);
-      } else {
-        // Single-line for date/account groups (no separate label)
-        lines.push(`${g.key} · ${stats}`);
-      }
-    }
-
-    return {
-      content: [{ type: 'text', text: lines.join('\n') }],
-      metadata: {
-        totalHours,
-        totalWorklogs: worklogs.length,
-        groupCount: groups.length,
-        groupBy,
-        startDate,
-        endDate,
-        details: groups,
-      },
-    };
-  } catch (error) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: `Failed to get worklog analytics: ${formatError(error)}`,
-        },
-      ],
-    };
-  }
 }
 
 function computeGroupKey(
@@ -968,7 +927,6 @@ function computeGroupKey(
   }
 }
 
-// ISO 8601 week date: YYYY-Www
 function toIsoWeek(dateStr: string): string {
   const date = new Date(`${dateStr}T00:00:00Z`);
   const dayNum = date.getUTCDay() || 7;

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,7 @@ export const getWorklogAnalyticsSchema = z.object({
 // API interfaces
 export interface JiraUser {
   accountId: string;
-  emailAddress: string;
+  emailAddress?: string;
   displayName?: string;
 }
 
@@ -239,4 +239,37 @@ export interface Config {
     tempoAccountCustomFieldId?: string;
   };
   server: { name: string; version: string };
+}
+
+/**
+ * Per-request context that drives Tempo + Jira API calls.
+ *
+ * Both transports (stdio and the Cloudflare Worker) build a Ctx and hand it
+ * to the tools/jira factories. Stdio derives Ctx from process.env once at
+ * startup; the Worker derives a fresh Ctx per user from KV-stored credentials.
+ *
+ * `refreshJira` is the seam that lets stdio support OAuth 2.0 PKCE without
+ * bundling oauth.ts (which uses fs/http/os) into the Worker. When set, the
+ * Jira factory invokes it before each request to swap in a freshly-refreshed
+ * access token. The Worker path leaves it undefined.
+ */
+export interface Ctx {
+  tempoApi: { baseUrl: string; token: string };
+  jiraApi: {
+    /** Site URL for basic/bearer, or api.atlassian.com/ex/jira/{cloudId} for oauth. */
+    baseUrl: string;
+    /** Static fallback token. Ignored when `refreshJira` is set. */
+    token: string;
+    /** Required for basic auth. */
+    email?: string;
+    authType: 'basic' | 'bearer' | 'oauth';
+    tempoAccountCustomFieldId?: string;
+  };
+  /**
+   * Resolves the current Jira bearer token. Set by stdio's OAuth path; left
+   * undefined for basic/bearer auth and for the Worker path. May also return a
+   * `baseUrl` override (the OAuth flow needs to swap to the Atlassian gateway
+   * once the cloudId is known).
+   */
+  refreshJira?: () => Promise<{ token: string; baseUrl?: string }>;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { getIssueInfoById } from './jira.js';
+import { JiraClient } from './jira.js';
 
 /**
  * Standard error handling for API errors
@@ -33,6 +33,7 @@ export function extractWorklogIssueIds(worklogs: any[]): string[] {
  * labels so a single deleted issue doesn't break the whole response.
  */
 export async function getIssueInfoMap(
+  jira: JiraClient,
   issueIds: (string | number)[],
 ): Promise<Record<string, { key: string; summary: string }>> {
   const unique = [...new Set(issueIds.map(String))];
@@ -42,7 +43,7 @@ export async function getIssueInfoMap(
   await Promise.all(
     unique.map(async (issueId) => {
       try {
-        map[issueId] = await getIssueInfoById(issueId);
+        map[issueId] = await jira.getIssueInfoById(issueId);
       } catch (error) {
         console.error(
           `Could not get info for issue ID ${issueId}: ${(error as Error).message}`,
@@ -81,19 +82,15 @@ export function calculateEndTime(
   startTime: string,
   hoursSpent: number,
 ): string {
-  // Parse the HH:MM format
   const [hours, minutes] = startTime.split(':').map((num) => parseInt(num, 10));
 
-  // Create a Date object with today's date but with the given hours and minutes
   const startTimeDate = new Date();
   startTimeDate.setHours(hours, minutes, 0, 0);
 
-  // Add the duration in milliseconds
   const endTimeDate = new Date(
     startTimeDate.getTime() + hoursSpent * 3600 * 1000,
   );
 
-  // Format the end time as HH:MM
   const endTime = `${endTimeDate.getHours().toString().padStart(2, '0')}:${endTimeDate.getMinutes().toString().padStart(2, '0')}`;
 
   return endTime;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,7 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "outDir": "./build",
-    "rootDir": "./src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.worker.json" }
+  ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/remote/**"]
+}

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src/remote/**/*",
+    "src/types.ts",
+    "src/jira.ts",
+    "src/tools.ts",
+    "src/utils.ts"
+  ],
+  "exclude": ["node_modules", "src/index.ts", "src/oauth.ts", "src/config.ts"]
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,49 @@
+/**
+ * Cloudflare Workers config for the remote Tempo MCP server.
+ *
+ * Required setup before first deploy:
+ *   1) wrangler kv namespace create USERS
+ *      → paste the returned id below into kv_namespaces[0].id
+ *   2) wrangler secret put ENCRYPTION_KEY
+ *      → paste 32+ random bytes (e.g. `openssl rand -base64 48`); used to
+ *        AES-GCM-encrypt per-user credentials at rest in KV
+ *
+ * Local dev (`wrangler dev`) uses a local KV store and reads ENCRYPTION_KEY
+ * from .dev.vars (gitignored). See .dev.vars.example.
+ *
+ * The server is intentionally stateless (no Durable Objects). Each MCP
+ * request reads + decrypts the user's credentials from KV, builds a fresh
+ * McpServer for that request, and dispatches via the official Cloudflare
+ * `createMcpHandler` from the `agents` SDK. Credentials are never held in
+ * memory across requests.
+ */
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "tempo-mcp-server",
+  "main": "src/remote/worker.ts",
+  "compatibility_date": "2026-01-28",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "enabled": true,
+  },
+  "kv_namespaces": [
+    {
+      "binding": "USERS",
+      // Run `npx wrangler kv namespace create USERS` and paste the returned id
+      // here before your first deploy. Each Cloudflare account has its own
+      // namespace ids; this is intentionally empty in the committed config.
+      "id": "",
+    },
+  ],
+  // Per-IP rate limit on /setup POST: 5 submissions per minute. Cheap defense
+  // against KV-write exhaustion on the free plan (1k writes/day) without any
+  // operator action. `namespace_id` is local to this Worker — pick any unique
+  // integer string.
+  "ratelimits": [
+    {
+      "name": "SETUP_RATE_LIMITER",
+      "namespace_id": "1",
+      "simple": { "limit": 5, "period": 60 },
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

Hosts a multi-tenant MCP server on Cloudflare Workers alongside the existing stdio binary, so end users can paste a personal URL into Claude.ai or ChatGPT instead of running anything locally.

- New `src/remote/{worker,agent,setup,storage}.ts` — Worker entrypoint, per-request McpServer factory, `/setup` onboarding form, and AES-GCM credential storage in Workers KV.
- `jira.ts` and `tools.ts` refactored onto a per-request `Ctx` so the same code serves stdio and the Worker without a process-wide config singleton. `oauth.ts` and the OAuth path stay stdio-only via dynamic import.
- Hardening: per-IP rate limit on POST `/setup` (Cloudflare Rate Limiting binding), `Cache-Control: no-store` + `Referrer-Policy: no-referrer` on `/setup`, AES-GCM 256 with per-record IV, 404-on-unknown-id for `/mcp/u_<id>`.
- Build split: `tsconfig.node.json` for the npm CLI, `tsconfig.worker.json` for the Worker bundle. The npm package still ships only `build/`.
- README documents fork-and-deploy, troubleshooting, and the \`ENCRYPTION_KEY\`-is-permanent caveat. \`wrangler.jsonc\` is committed with an empty KV id so each deployer wires their own.

Existing stdio users see no behaviour change — same 7 tools, same env vars, same build artefact.

## Test plan

- [x] \`npm run build\` (Node CLI bundle)
- [x] \`npm run remote:typecheck\` (Worker bundle)
- [x] \`npm run lint\` (0 errors)
- [x] \`npm run format:check\`
- [x] \`npx wrangler deploy --dry-run\` — confirms KV + rate-limit bindings
- [ ] Live deploy to Cloudflare and end-to-end test via Claude.ai connector