### PR TITLE
chore: commit upstream KV namespace id in wrangler.jsonc

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,7 @@ npx wrangler login
 npx wrangler kv namespace create USERS
 ```
 
-> ⚠️ **Important:** copy the `id` returned by step 2 and paste it into [`wrangler.jsonc`](wrangler.jsonc) → `kv_namespaces[0].id`. The committed value is intentionally empty — `wrangler deploy` will fail with `KV namespace … is not valid` until you fill it in. KV namespace ids are per-account and aren't sensitive, but each fork needs its own.
->
-> If you want to keep your local id out of `git diff` after editing, run once: `git update-index --skip-worktree wrangler.jsonc`. Reverse with `--no-skip-worktree` when you need to commit other config changes.
+> ⚠️ **If you forked the repo:** the committed [`wrangler.jsonc`](wrangler.jsonc) `kv_namespaces[0].id` belongs to the upstream maintainer's Cloudflare account. Replace it with the id step 2 just returned, otherwise `wrangler deploy` will fail with `KV namespace … is not valid`. KV namespace ids are public per-account identifiers, not secrets, but each account has its own.
 
 ```bash
 # 3. Generate and store the encryption key.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -29,10 +29,10 @@
   "kv_namespaces": [
     {
       "binding": "USERS",
-      // Run `npx wrangler kv namespace create USERS` and paste the returned id
-      // here before your first deploy. Each Cloudflare account has its own
-      // namespace ids; this is intentionally empty in the committed config.
-      "id": "",
+      // KV namespace id — public identifier, not a secret. If you forked the
+      // repo, run `npx wrangler kv namespace create USERS` and replace this
+      // value with the id Cloudflare returns for your account.
+      "id": "9bf87d2cb1084c07b40b5cd41694ea02",
     },
   ],
   // Per-IP rate limit on /setup POST: 5 submissions per minute. Cheap defense


### PR DESCRIPTION
## Summary

Commits the upstream maintainer's KV namespace id (\`9bf87d2cb1...\`) into \`wrangler.jsonc\` so \`npm run remote:deploy\` works on this account without local edits or \`--skip-worktree\` tricks.

KV namespace ids are per-account public routing identifiers, not secrets — Cloudflare blocks any other account from using them. Forks still need to replace the value with their own id; the README warning is reworded to match.

## Test plan

- [x] \`npm run format:check\`
- [x] \`npm run remote:typecheck\`
- [x] \`wrangler deploy\` — Worker live at https://tempo-mcp-server.ivelinivanov1999.workers.dev (already deployed against this id, just making the local edit committed)