### PR TITLE
Add multi-user worklog filters (users, program, team) to read tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ You can run the server directly with Node by pointing to the built JavaScript fi
      - **Worklogs** (View + Manage) — for all worklog tools
      - **Schemes** (View) — required for `getMissingWorklogDays` (reads the user-schedule)
      - **Accounts** (View) — only if your worklogs use Tempo accounts
+     - **Teams** (View) — only if you use the `program` / `team` filters (covers Teams and Programs)
    - Tempo does not allow editing scopes on an existing token; create a new one if you need to add scopes later.
 
 2. **Jira API Token**:
@@ -336,16 +337,35 @@ To find your custom field ID:
 1. Go to Jira Settings → Issues → Custom Fields
 2. Find your Tempo account field and note the ID from the URL or field configuration
 
+## Viewing Other Users' Worklogs
+
+The read tools (`retrieveWorklogs`, `getWorklogAnalytics`, `getMissingWorklogDays`) default to the token owner's own worklogs, but accept optional filters to target other people — useful for admins, PMs, and team leads:
+
+- `users` — array of emails, display names, or Jira accountIds (e.g. `["ivan@company.com", "Maria Petrova"]`)
+- `program` — Tempo Program name or id; expands to all current members of the program's teams
+- `team` — Tempo Team name or id; expands to all current team members
+
+Filters combine as a union. Tempo enforces permissions **server-side**: the API silently omits worklogs the token owner isn't allowed to see (no error is returned). To view other users you need:
+
+1. A Tempo **Permission Role** with **View Worklogs** granted to the token owner (Tempo > Settings > Permission Roles) — "Full" for everyone, or "Restricted" + selected teams
+2. Jira **Browse Projects** permission on the relevant projects
+3. The **Teams** scope on the Tempo API token if you use the `program` / `team` filters
+
+`getWorklogAnalytics` also supports `groupBy: "user"` — combined with `program`, it produces a per-person hours report in a single call. `getMissingWorklogDays` with a filter returns a per-user report of days with missing time (viewing other users' schedules is also permission-gated).
+
 ## Available Tools
 
 ### retrieveWorklogs
 
-Fetches worklogs for the configured user between start and end dates.
+Fetches worklogs for the configured user (or other users via filters) between start and end dates.
 
 ```
 Parameters:
 - startDate: String (YYYY-MM-DD)
 - endDate: String (YYYY-MM-DD)
+- users: String[] (optional) — emails, display names, or accountIds
+- program: String (optional) — Tempo Program name or id
+- team: String (optional) — Tempo Team name or id
 ```
 
 ### createWorklog
@@ -400,7 +420,7 @@ Parameters:
 
 ### getMissingWorklogDays
 
-Reports working days in a date range where the user has logged less time than expected. Expected hours per day come from the user's Tempo schedule, so holidays, non-working days, and part-time schedules are honoured automatically.
+Reports working days in a date range where the user has logged less time than expected. Expected hours per day come from the user's Tempo schedule, so holidays, non-working days, and part-time schedules are honoured automatically. With `users` / `program` / `team` it checks other people and returns a per-user report (sorted by most missing hours).
 
 ```
 Parameters:
@@ -408,19 +428,25 @@ Parameters:
 - endDate: String (YYYY-MM-DD)
 - minHoursPerDay: Number (optional) — override the per-day threshold;
                                       non-working days are still skipped
+- users: String[] (optional) — emails, display names, or accountIds
+- program: String (optional) — Tempo Program name or id
+- team: String (optional) — Tempo Team name or id
 ```
 
 > **Required Tempo scope:** the `TEMPO_API_TOKEN` must include the **Schemes** scope (covers Workload Schemes, Holiday Schemes, User Schedule) in addition to **Worklogs**. Tempo does not allow modifying scopes on an existing token — if your current token only has Worklogs, create a new one at Tempo > Settings > API Integration.
 
 ### getWorklogAnalytics
 
-Aggregates worklogs in a date range and returns hours, worklog count, and percentage per group, sorted by hours descending.
+Aggregates worklogs in a date range and returns hours, worklog count, and percentage per group, sorted by hours descending. Combine `groupBy: "user"` with `program` / `team` / `users` for a per-person report.
 
 ```
 Parameters:
 - startDate: String (YYYY-MM-DD)
 - endDate: String (YYYY-MM-DD)
-- groupBy: "issue" | "account" | "day" | "week" | "month" (optional, default "issue")
+- groupBy: "issue" | "account" | "user" | "day" | "week" | "month" (optional, default "issue")
+- users: String[] (optional) — emails, display names, or accountIds
+- program: String (optional) — Tempo Program name or id
+- team: String (optional) — Tempo Team name or id
 ```
 
 ## Project Structure
@@ -428,6 +454,7 @@ Parameters:
 ```
 tempo-mcp-server/
 ├── src/                  # Source code
+│   ├── authors.ts        # Author filter resolution (users/program/team → accountIds)
 │   ├── config.ts         # Configuration management
 │   ├── index.ts          # MCP server implementation
 │   ├── jira.ts           # Jira API integration

--- a/src/authors.ts
+++ b/src/authors.ts
@@ -1,0 +1,300 @@
+import axios, { AxiosInstance } from 'axios';
+import { JiraClient } from './jira.js';
+import { AuthorFilter, JiraUser } from './types.js';
+import { fetchAllTempoPages, mapWithConcurrency } from './utils.js';
+
+/** A worklog author resolved to a Jira accountId with a human-readable label. */
+export interface ResolvedAuthor {
+  accountId: string;
+  label: string;
+}
+
+export function hasAuthorFilter(filter?: AuthorFilter): filter is AuthorFilter {
+  return !!(
+    filter &&
+    ((filter.users?.length ?? 0) > 0 || filter.program || filter.team)
+  );
+}
+
+// Atlassian accountIds are either 24-char hex (legacy) or `<prefix>:<uuid>`
+// (e.g. "557058:f58131cb-…"). Display names and emails never match either.
+const ACCOUNT_ID_RE = /^([0-9a-f]{24}|[a-zA-Z0-9]+:[a-zA-Z0-9-]{8,})$/i;
+
+export function userLabel(user: JiraUser): string {
+  if (!user.displayName) return user.accountId;
+  return user.emailAddress
+    ? `${user.displayName} <${user.emailAddress}>`
+    : user.displayName;
+}
+
+function describeCandidates(users: JiraUser[]): string {
+  const shown = users
+    .slice(0, 10)
+    .map((u) => `${u.displayName ?? 'Unknown'} (${u.accountId})`);
+  const suffix = users.length > 10 ? `, … ${users.length - 10} more` : '';
+  return shown.join(', ') + suffix;
+}
+
+async function resolveUserEntry(
+  jira: JiraClient,
+  entry: string,
+): Promise<ResolvedAuthor> {
+  const value = entry.trim();
+  if (ACCOUNT_ID_RE.test(value)) {
+    return { accountId: value, label: value };
+  }
+
+  const candidates = await jira.searchUsers(value);
+
+  if (value.includes('@')) {
+    const exact = candidates.filter(
+      (u) => u.emailAddress?.toLowerCase() === value.toLowerCase(),
+    );
+    if (exact.length >= 1) {
+      return { accountId: exact[0].accountId, label: userLabel(exact[0]) };
+    }
+    // Email hidden by privacy settings but the query still matched server-side.
+    if (candidates.length === 1) {
+      return {
+        accountId: candidates[0].accountId,
+        label: userLabel(candidates[0]),
+      };
+    }
+    if (candidates.length === 0) {
+      // Jira privacy settings can exclude emails from search entirely. Most
+      // org emails are name-based ("ivan.petrov@x"), so retry the local part
+      // as a display name and accept only an unambiguous match.
+      const nameGuess = value
+        .split('@')[0]
+        .replace(/[._-]+/g, ' ')
+        .trim();
+      if (nameGuess) {
+        const byName = await jira.searchUsers(nameGuess);
+        const exactName = byName.filter(
+          (u) => u.displayName?.toLowerCase() === nameGuess.toLowerCase(),
+        );
+        const pool = exactName.length > 0 ? exactName : byName;
+        if (pool.length === 1) {
+          return { accountId: pool[0].accountId, label: userLabel(pool[0]) };
+        }
+      }
+      throw new Error(
+        `No Jira user found for email "${value}". Jira privacy settings may ` +
+          'exclude emails from search — try the display name or accountId instead.',
+      );
+    }
+    throw new Error(
+      `Email "${value}" matched ${candidates.length} Jira users and none exposes a matching email address (visibility may be restricted): ${describeCandidates(candidates)}. Pass an accountId instead.`,
+    );
+  }
+
+  const exact = candidates.filter(
+    (u) => u.displayName?.toLowerCase() === value.toLowerCase(),
+  );
+  const pool = exact.length > 0 ? exact : candidates;
+  if (pool.length === 1) {
+    return { accountId: pool[0].accountId, label: userLabel(pool[0]) };
+  }
+  if (pool.length === 0) {
+    throw new Error(`No Jira user found matching "${value}".`);
+  }
+  throw new Error(
+    `"${value}" matches ${pool.length} Jira users: ${describeCandidates(pool)}. Use an email or accountId to disambiguate.`,
+  );
+}
+
+function throwWithTeamsScopeHint(error: unknown, what: string): never {
+  if (axios.isAxiosError(error) && error.response?.status === 403) {
+    throw new Error(
+      `Tempo API returned 403 while fetching ${what}. Your TEMPO_API_TOKEN is ` +
+        'likely missing the "Teams" scope (covers Teams and Programs). Tempo ' +
+        'does not allow modifying scopes on an existing token — create a new ' +
+        'token at Tempo > Settings > API Integration with the "Teams" scope, ' +
+        'then update TEMPO_API_TOKEN.',
+    );
+  }
+  throw error;
+}
+
+interface NamedRef {
+  id: number;
+  name: string;
+}
+
+function describeRefs(items: NamedRef[]): string {
+  const shown = items.slice(0, 25).map((i) => `"${i.name}" (id ${i.id})`);
+  const suffix = items.length > 25 ? `, … ${items.length - 25} more` : '';
+  return shown.join(', ') + suffix;
+}
+
+function matchByIdOrName(
+  items: NamedRef[],
+  query: string,
+  kind: 'program' | 'team',
+): NamedRef {
+  const trimmed = query.trim();
+  if (/^\d+$/.test(trimmed)) {
+    const byId = items.find((i) => String(i.id) === trimmed);
+    if (byId) return byId;
+  }
+
+  const lower = trimmed.toLowerCase();
+  const exact = items.filter((i) => i.name?.toLowerCase() === lower);
+  if (exact.length === 1) return exact[0];
+  const partial = items.filter((i) => i.name?.toLowerCase().includes(lower));
+  if (exact.length === 0 && partial.length === 1) return partial[0];
+
+  const ambiguous = exact.length > 1 ? exact : partial;
+  if (ambiguous.length > 1) {
+    throw new Error(
+      `Tempo ${kind} "${query}" is ambiguous — matches: ${describeRefs(ambiguous)}. Use the numeric id.`,
+    );
+  }
+  if (items.length === 0) {
+    throw new Error(`No Tempo ${kind}s are visible to this token.`);
+  }
+  throw new Error(
+    `Tempo ${kind} "${query}" not found. Available: ${describeRefs(items)}.`,
+  );
+}
+
+async function resolveProgramTeamIds(
+  tempo: AxiosInstance,
+  program: string,
+): Promise<number[]> {
+  let programs: NamedRef[];
+  try {
+    const response = await tempo.get('/programs');
+    programs = response.data?.results || [];
+  } catch (error) {
+    throwWithTeamsScopeHint(error, 'programs');
+  }
+
+  const match = matchByIdOrName(programs, program, 'program');
+
+  // Preferred path — needs "view program" permission in Tempo, which many
+  // team leads don't have even when they can see the teams themselves.
+  try {
+    const response = await tempo.get(`/programs/${match.id}/teams`);
+    const teams: NamedRef[] = response.data?.results || [];
+    if (teams.length > 0) return teams.map((t) => t.id);
+  } catch {
+    // Typically 400 "You do not have permission to view program" —
+    // fall back to the team listing below.
+  }
+
+  // Fallback: every visible team carries a program reference, so filter the
+  // team list. Covers exactly the teams the token owner is allowed to see.
+  let allTeams: Array<NamedRef & { program?: { id: number } }>;
+  try {
+    allTeams = await fetchAllTempoPages(tempo, '/teams', { limit: 100 });
+  } catch (error) {
+    throwWithTeamsScopeHint(error, 'teams');
+  }
+  const teamIds = allTeams
+    .filter((t) => t.program?.id === match.id)
+    .map((t) => t.id);
+
+  if (teamIds.length === 0) {
+    throw new Error(
+      `No teams of Tempo program "${match.name}" are visible to this token. ` +
+        'Either the program has no teams, or you lack permission to view ' +
+        "them — ask a Tempo admin to grant access to the program's teams.",
+    );
+  }
+  return teamIds;
+}
+
+async function resolveTeamId(
+  tempo: AxiosInstance,
+  team: string,
+): Promise<number> {
+  let teams: NamedRef[];
+  try {
+    teams = await fetchAllTempoPages(tempo, '/teams', { limit: 100 });
+  } catch (error) {
+    throwWithTeamsScopeHint(error, 'teams');
+  }
+  return matchByIdOrName(teams, team, 'team').id;
+}
+
+async function fetchTeamMemberIds(
+  tempo: AxiosInstance,
+  teamIds: number[],
+): Promise<string[]> {
+  const perTeam = await mapWithConcurrency(teamIds, 5, async (teamId) => {
+    try {
+      return await fetchAllTempoPages(tempo, `/teams/${teamId}/members`, {});
+    } catch (error) {
+      throwWithTeamsScopeHint(error, `members of team ${teamId}`);
+    }
+  });
+
+  const ids = new Set<string>();
+  for (const membership of perTeam.flat()) {
+    const accountId = membership?.member?.accountId;
+    if (accountId) ids.add(accountId);
+  }
+  return [...ids];
+}
+
+/**
+ * Resolve an author filter to concrete worklog authors.
+ *
+ * `users` entries go through Jira user search (accountId passthrough, email,
+ * or display name). `program`/`team` expand to the *current* members of the
+ * matching Tempo teams. All sources are unioned and de-duplicated, then
+ * labelled with display names via a best-effort Jira bulk lookup.
+ *
+ * Throws with an actionable message when anything is ambiguous or missing —
+ * callers surface the error text as-is.
+ */
+export async function resolveAuthorFilter(
+  tempo: AxiosInstance,
+  jira: JiraClient,
+  filter: AuthorFilter,
+): Promise<ResolvedAuthor[]> {
+  const byId = new Map<string, ResolvedAuthor>();
+
+  if (filter.users?.length) {
+    const resolved = await mapWithConcurrency(filter.users, 5, (entry) =>
+      resolveUserEntry(jira, entry),
+    );
+    for (const author of resolved) byId.set(author.accountId, author);
+  }
+
+  const teamIds: number[] = [];
+  if (filter.program) {
+    teamIds.push(...(await resolveProgramTeamIds(tempo, filter.program)));
+  }
+  if (filter.team) {
+    teamIds.push(await resolveTeamId(tempo, filter.team));
+  }
+  if (teamIds.length > 0) {
+    const memberIds = await fetchTeamMemberIds(tempo, [...new Set(teamIds)]);
+    for (const accountId of memberIds) {
+      if (!byId.has(accountId))
+        byId.set(accountId, { accountId, label: accountId });
+    }
+  }
+
+  if (byId.size === 0) {
+    throw new Error(
+      'The author filter matched no users (the program/team may have no current members).',
+    );
+  }
+
+  // Best effort: swap accountId labels for display names.
+  const unlabeled = [...byId.values()]
+    .filter((a) => a.label === a.accountId)
+    .map((a) => a.accountId);
+  if (unlabeled.length > 0) {
+    const users = await jira.getUsersByAccountIds(unlabeled);
+    for (const [accountId, user] of Object.entries(users)) {
+      const author = byId.get(accountId);
+      if (author) author.label = userLabel(user);
+    }
+  }
+
+  return [...byId.values()];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,10 +82,18 @@ async function startServer(): Promise<void> {
 
     server.registerTool(
       'retrieveWorklogs',
-      { inputSchema: retrieveWorklogsSchema.shape },
-      async ({ startDate, endDate }) => {
+      {
+        description:
+          "Retrieve Tempo worklogs in a date range. Defaults to the authenticated user's own worklogs. Optional filters fetch other users' worklogs instead: 'users' (emails, display names, or accountIds), 'program' / 'team' (all current members of the Tempo program/team; name or id). Filters combine as a union. Viewing others requires the Tempo token owner to have a Permission Role with 'View Worklogs' plus Jira 'Browse Projects' — otherwise Tempo silently returns only permitted worklogs.",
+        inputSchema: retrieveWorklogsSchema.shape,
+      },
+      async ({ startDate, endDate, users, program, team }) => {
         try {
-          const result = await tools.retrieveWorklogs(startDate, endDate);
+          const result = await tools.retrieveWorklogs(startDate, endDate, {
+            users,
+            program,
+            team,
+          });
           return {
             content: result.content,
             ...(result.isError && { isError: true }),
@@ -247,15 +255,16 @@ async function startServer(): Promise<void> {
       'getMissingWorklogDays',
       {
         description:
-          "Find working days in a date range where the user's logged time is below the expected hours from their Tempo user-schedule. Holidays and non-working days are skipped automatically. Returns days with their expected vs logged hours, plus a per-issue breakdown for partially-logged days. Requires the 'Schemes' scope on the Tempo API token (in addition to 'Worklogs').",
+          "Find working days in a date range where the user's logged time is below the expected hours from their Tempo user-schedule. Holidays and non-working days are skipped automatically. Returns days with their expected vs logged hours, plus a per-issue breakdown for partially-logged days. Requires the 'Schemes' scope on the Tempo API token (in addition to 'Worklogs'). Pass 'users' / 'program' / 'team' to check other people instead — returns a per-user report (requires permission to view their worklogs and schedules).",
         inputSchema: getMissingWorklogDaysSchema.shape,
       },
-      async ({ startDate, endDate, minHoursPerDay }) => {
+      async ({ startDate, endDate, minHoursPerDay, users, program, team }) => {
         try {
           const result = await tools.getMissingWorklogDays(
             startDate,
             endDate,
             minHoursPerDay,
+            { users, program, team },
           );
           return {
             content: result.content,
@@ -282,15 +291,16 @@ async function startServer(): Promise<void> {
       'getWorklogAnalytics',
       {
         description:
-          "Aggregate worklogs in a date range and return hours, worklog count, and percentage per group, sorted by hours descending. groupBy options: 'issue' (default), 'account', 'day', 'week' (ISO 8601), 'month'. Note: 'account' grouping reads the _Account_ work attribute on each worklog — worklogs without an account attribute are bucketed as 'No account', so this grouping is only meaningful if your team uses Tempo accounts.",
+          "Aggregate worklogs in a date range and return hours, worklog count, and percentage per group, sorted by hours descending. groupBy options: 'issue' (default), 'account', 'user', 'day', 'week' (ISO 8601), 'month'. Pass 'users' / 'program' / 'team' to analyze other people's worklogs (e.g. groupBy 'user' + program gives a per-person report for the whole program; requires 'View Worklogs' permission). Note: 'account' grouping reads the _Account_ work attribute on each worklog — worklogs without an account attribute are bucketed as 'No account', so this grouping is only meaningful if your team uses Tempo accounts.",
         inputSchema: getWorklogAnalyticsSchema.shape,
       },
-      async ({ startDate, endDate, groupBy }) => {
+      async ({ startDate, endDate, groupBy, users, program, team }) => {
         try {
           const result = await tools.getWorklogAnalytics(
             startDate,
             endDate,
             groupBy,
+            { users, program, team },
           );
           return {
             content: result.content,

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -11,6 +11,8 @@ export interface JiraClient {
     key: string;
     tempoAccountId?: string;
   }>;
+  searchUsers(query: string): Promise<JiraUser[]>;
+  getUsersByAccountIds(accountIds: string[]): Promise<Record<string, JiraUser>>;
 }
 
 function basicAuthHeader(email: string, token: string): string {
@@ -116,6 +118,82 @@ export function createJiraClient(ctx: Ctx): JiraClient {
         }
         throw formatJiraError(myselfError, 'Failed to get user account ID');
       }
+    },
+
+    /**
+     * Search Jira users by display name or email.
+     *
+     * Requires the "Browse users and groups" global permission. When email
+     * visibility is restricted (Atlassian privacy settings), the server still
+     * matches the query against the email — the address is just absent from
+     * the response, so callers must handle results without `emailAddress`.
+     */
+    async searchUsers(query: string): Promise<JiraUser[]> {
+      try {
+        const jiraApi = await client();
+        const response = await jiraApi.get<JiraUser[]>(
+          '/rest/api/3/user/search',
+          { params: { query, maxResults: 50 } },
+        );
+        // Humans only — app/customer accounts can't author Tempo worklogs.
+        return (response.data || []).filter(
+          (u) => !u.accountType || u.accountType === 'atlassian',
+        );
+      } catch (error) {
+        throw formatJiraError(
+          error,
+          `Failed to search Jira users for "${query}" (requires the "Browse users and groups" permission)`,
+        );
+      }
+    },
+
+    /**
+     * Resolve accountIds to Jira users (for display names) via /user/bulk.
+     *
+     * Best effort: returns whatever resolves and swallows errors — display
+     * names are cosmetic, so a missing "Browse users and groups" permission
+     * degrades labels to accountIds instead of failing the tool call.
+     */
+    async getUsersByAccountIds(
+      accountIds: string[],
+    ): Promise<Record<string, JiraUser>> {
+      const unique = [...new Set(accountIds)];
+      const map: Record<string, JiraUser> = {};
+      if (unique.length === 0) return map;
+
+      const CHUNK_SIZE = 90;
+      try {
+        const jiraApi = await client();
+        for (let i = 0; i < unique.length; i += CHUNK_SIZE) {
+          const chunk = unique.slice(i, i + CHUNK_SIZE);
+          let startAt = 0;
+          let isLast = false;
+          while (!isLast) {
+            // accountId must repeat as accountId=a&accountId=b — build the
+            // query string manually to avoid Axios' array bracket encoding.
+            const params = new URLSearchParams();
+            chunk.forEach((id) => {
+              params.append('accountId', id);
+            });
+            params.set('maxResults', String(CHUNK_SIZE));
+            params.set('startAt', String(startAt));
+
+            const response = await jiraApi.get(
+              `/rest/api/3/user/bulk?${params.toString()}`,
+            );
+            const values: JiraUser[] = response.data?.values || [];
+            for (const user of values) map[user.accountId] = user;
+
+            isLast = response.data?.isLast !== false || values.length === 0;
+            startAt += values.length;
+          }
+        }
+      } catch (error) {
+        console.error(
+          `Could not resolve user display names: ${(error as Error).message}`,
+        );
+      }
+      return map;
     },
 
     /**

--- a/src/remote/agent.ts
+++ b/src/remote/agent.ts
@@ -52,10 +52,18 @@ export function buildMcpServer(creds: UserCredentials): McpServer {
 
   server.registerTool(
     'retrieveWorklogs',
-    { inputSchema: retrieveWorklogsSchema.shape },
-    async ({ startDate, endDate }) => {
+    {
+      description:
+        "Retrieve Tempo worklogs in a date range. Defaults to the authenticated user's own worklogs. Optional filters fetch other users' worklogs instead: 'users' (emails, display names, or accountIds), 'program' / 'team' (all current members of the Tempo program/team; name or id). Filters combine as a union. Viewing others requires the Tempo token owner to have a Permission Role with 'View Worklogs' plus Jira 'Browse Projects' — otherwise Tempo silently returns only permitted worklogs.",
+      inputSchema: retrieveWorklogsSchema.shape,
+    },
+    async ({ startDate, endDate, users, program, team }) => {
       try {
-        const result = await tools.retrieveWorklogs(startDate, endDate);
+        const result = await tools.retrieveWorklogs(startDate, endDate, {
+          users,
+          program,
+          team,
+        });
         return {
           content: result.content,
           ...(result.isError && { isError: true }),
@@ -162,15 +170,16 @@ export function buildMcpServer(creds: UserCredentials): McpServer {
     'getMissingWorklogDays',
     {
       description:
-        "Find working days in a date range where the user's logged time is below the expected hours from their Tempo user-schedule. Holidays and non-working days are skipped automatically. Returns days with their expected vs logged hours, plus a per-issue breakdown for partially-logged days. Requires the 'Schemes' scope on the Tempo API token (in addition to 'Worklogs').",
+        "Find working days in a date range where the user's logged time is below the expected hours from their Tempo user-schedule. Holidays and non-working days are skipped automatically. Returns days with their expected vs logged hours, plus a per-issue breakdown for partially-logged days. Requires the 'Schemes' scope on the Tempo API token (in addition to 'Worklogs'). Pass 'users' / 'program' / 'team' to check other people instead — returns a per-user report (requires permission to view their worklogs and schedules).",
       inputSchema: getMissingWorklogDaysSchema.shape,
     },
-    async ({ startDate, endDate, minHoursPerDay }) => {
+    async ({ startDate, endDate, minHoursPerDay, users, program, team }) => {
       try {
         const result = await tools.getMissingWorklogDays(
           startDate,
           endDate,
           minHoursPerDay,
+          { users, program, team },
         );
         return {
           content: result.content,
@@ -186,15 +195,16 @@ export function buildMcpServer(creds: UserCredentials): McpServer {
     'getWorklogAnalytics',
     {
       description:
-        "Aggregate worklogs in a date range and return hours, worklog count, and percentage per group, sorted by hours descending. groupBy options: 'issue' (default), 'account', 'day', 'week' (ISO 8601), 'month'. Note: 'account' grouping reads the _Account_ work attribute on each worklog — worklogs without an account attribute are bucketed as 'No account', so this grouping is only meaningful if your team uses Tempo accounts.",
+        "Aggregate worklogs in a date range and return hours, worklog count, and percentage per group, sorted by hours descending. groupBy options: 'issue' (default), 'account', 'user', 'day', 'week' (ISO 8601), 'month'. Pass 'users' / 'program' / 'team' to analyze other people's worklogs (e.g. groupBy 'user' + program gives a per-person report for the whole program; requires 'View Worklogs' permission). Note: 'account' grouping reads the _Account_ work attribute on each worklog — worklogs without an account attribute are bucketed as 'No account', so this grouping is only meaningful if your team uses Tempo accounts.",
       inputSchema: getWorklogAnalyticsSchema.shape,
     },
-    async ({ startDate, endDate, groupBy }) => {
+    async ({ startDate, endDate, groupBy, users, program, team }) => {
       try {
         const result = await tools.getWorklogAnalytics(
           startDate,
           endDate,
           groupBy,
+          { users, program, team },
         );
         return {
           content: result.content,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -10,9 +10,16 @@ import {
   MissingWorklogDay,
   AnalyticsGroup,
   AnalyticsGroupBy,
+  AuthorFilter,
   Ctx,
 } from './types.js';
 import { createJiraClient, JiraClient } from './jira.js';
+import {
+  hasAuthorFilter,
+  resolveAuthorFilter,
+  userLabel,
+  ResolvedAuthor,
+} from './authors.js';
 import {
   formatError,
   getIssueInfoMap,
@@ -20,6 +27,7 @@ import {
   calculateEndTime,
   formatHours,
   formatPercent,
+  mapWithConcurrency,
 } from './utils.js';
 
 // Tempo's /worklogs endpoints accept up to limit=1000 per page (sibling
@@ -31,8 +39,20 @@ const TEMPO_PAGE_LIMIT = 1000;
 // worklogs / 100,000 schedule entries, well beyond any realistic query.
 const MAX_PAGES = 500;
 
+// Shown whenever a multi-user query returns suspiciously little — Tempo
+// filters by permission server-side instead of erroring.
+const VIEW_OTHERS_HINT =
+  'Note: Tempo silently omits worklogs the token owner has no permission to ' +
+  'view. To see other users, the person who created the TEMPO_API_TOKEN ' +
+  'needs a Permission Role with "View Worklogs" (Tempo > Settings > ' +
+  'Permission Roles) and Jira "Browse Projects" on the relevant projects.';
+
 export interface Tools {
-  retrieveWorklogs(startDate: string, endDate: string): Promise<ToolResponse>;
+  retrieveWorklogs(
+    startDate: string,
+    endDate: string,
+    filter?: AuthorFilter,
+  ): Promise<ToolResponse>;
   createWorklog(
     issueKey: string,
     timeSpentHours: number,
@@ -55,11 +75,13 @@ export interface Tools {
     startDate: string,
     endDate: string,
     minHoursPerDay?: number,
+    filter?: AuthorFilter,
   ): Promise<ToolResponse>;
   getWorklogAnalytics(
     startDate: string,
     endDate: string,
     groupBy?: AnalyticsGroupBy,
+    filter?: AuthorFilter,
   ): Promise<ToolResponse>;
 }
 
@@ -75,13 +97,71 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
     },
   });
 
+  // Resolve the optional author filter (users/program/team) to accountIds.
+  // Returns null when no filter is set — the "own worklogs" default path.
+  async function resolveAuthors(
+    filter?: AuthorFilter,
+  ): Promise<ResolvedAuthor[] | null> {
+    return hasAuthorFilter(filter)
+      ? await resolveAuthorFilter(api, jiraClient, filter)
+      : null;
+  }
+
+  // Multi-user fetch via POST /worklogs/search. Pagination is offset-based:
+  // `metadata.next` can't be followed directly since it requires re-POSTing
+  // the body, so its presence just signals another page.
+  async function searchWorklogsForAuthors(
+    startDate: string,
+    endDate: string,
+    authorIds: string[],
+  ): Promise<{ worklogs: any[]; pagesProcessed: number }> {
+    let allWorklogs: any[] = [];
+    let offset = 0;
+    let pageCount = 0;
+    let hasNext = true;
+
+    while (hasNext) {
+      if (pageCount >= MAX_PAGES) {
+        throw new Error(
+          `Reached maximum page limit (${MAX_PAGES}) while searching worklogs ` +
+            `for ${startDate}..${endDate}. Results would be incomplete — ` +
+            `narrow the date range and try again.`,
+        );
+      }
+
+      const response = await api.post(
+        '/worklogs/search',
+        { from: startDate, to: endDate, authorIds },
+        { params: { offset, limit: TEMPO_PAGE_LIMIT } },
+      );
+
+      allWorklogs = allWorklogs.concat(response.data.results || []);
+      hasNext = !!response.data.metadata?.next;
+      // Advance by the limit the server actually applied, in case it clamps
+      // our requested page size — otherwise we'd skip records.
+      offset += Number(response.data.metadata?.limit) || TEMPO_PAGE_LIMIT;
+      pageCount++;
+    }
+
+    return { worklogs: allWorklogs, pagesProcessed: pageCount };
+  }
+
   // Helper: paginated fetch from Tempo `metadata.next` URLs.
   // Tempo's "next" URLs are absolute and don't include the bearer header —
   // we re-attach it on each follow-up request.
+  // With `authorIds` set, fetches those users' worklogs instead of the
+  // token owner's.
   async function fetchAllWorklogs(
     startDate: string,
     endDate: string,
+    authorIds?: string[],
   ): Promise<{ worklogs: any[]; pagesProcessed: number }> {
+    // Length guard matters: an empty authorIds array would make the search
+    // return every worklog visible to the token instead of nothing.
+    if (authorIds && authorIds.length > 0) {
+      return searchWorklogsForAuthors(startDate, endDate, authorIds);
+    }
+
     const accountId = await jiraClient.getCurrentUserAccountId();
 
     let allWorklogs: any[] = [];
@@ -142,6 +222,7 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
     accountId: string,
     startDate: string,
     endDate: string,
+    forOtherUser = false,
   ): Promise<DaySchedule[]> {
     let allDays: DaySchedule[] = [];
     let nextUrl: string | null = null;
@@ -186,12 +267,16 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.status === 403) {
         throw new Error(
-          'Tempo API returned 403 for /user-schedule. Your TEMPO_API_TOKEN ' +
-            'is missing the "Schemes" scope (which covers Workload Schemes, ' +
-            'Holiday Schemes, and User Schedule). Tempo does not allow ' +
-            'modifying scopes on an existing token — create a new token at ' +
-            'Tempo > Settings > API Integration with both "Worklogs" and ' +
-            '"Schemes" scopes, then update TEMPO_API_TOKEN.',
+          forOtherUser
+            ? `Tempo API returned 403 for /user-schedule/${accountId}. Either ` +
+              'the TEMPO_API_TOKEN is missing the "Schemes" scope, or the ' +
+              "token owner has no permission to view this user's schedule."
+            : 'Tempo API returned 403 for /user-schedule. Your TEMPO_API_TOKEN ' +
+              'is missing the "Schemes" scope (which covers Workload Schemes, ' +
+              'Holiday Schemes, and User Schedule). Tempo does not allow ' +
+              'modifying scopes on an existing token — create a new token at ' +
+              'Tempo > Settings > API Integration with both "Worklogs" and ' +
+              '"Schemes" scopes, then update TEMPO_API_TOKEN.',
         );
       }
       throw error;
@@ -218,15 +303,180 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
     return null;
   }
 
+  interface PerUserMissing {
+    author: ResolvedAuthor;
+    missing?: MissingWorklogDay[];
+    missingHours: number;
+    noSchedule?: boolean;
+    error?: string;
+  }
+
+  // Multi-user variant of getMissingWorklogDays: one worklog search covering
+  // all authors + one schedule fetch per author (bounded concurrency), then a
+  // per-user report sorted by most missing hours first.
+  async function missingWorklogDaysForUsers(
+    startDate: string,
+    endDate: string,
+    overrideSeconds: number | null,
+    authors: ResolvedAuthor[],
+  ): Promise<ToolResponse> {
+    const { worklogs } = await fetchAllWorklogs(
+      startDate,
+      endDate,
+      authors.map((a) => a.accountId),
+    );
+
+    const worklogsByAuthor = new Map<string, any[]>();
+    for (const w of worklogs) {
+      const id = w.author?.accountId;
+      if (!id) continue;
+      let list = worklogsByAuthor.get(id);
+      if (!list) {
+        list = [];
+        worklogsByAuthor.set(id, list);
+      }
+      list.push(w);
+    }
+
+    const perUser = await mapWithConcurrency(
+      authors,
+      5,
+      async (author): Promise<PerUserMissing> => {
+        try {
+          const schedule = await fetchUserSchedule(
+            author.accountId,
+            startDate,
+            endDate,
+            true,
+          );
+          if (schedule.length === 0) {
+            return { author, missingHours: 0, noSchedule: true };
+          }
+          const missing = computeMissingDays(
+            schedule,
+            worklogsByAuthor.get(author.accountId) ?? [],
+            overrideSeconds,
+          );
+          const missingHours = missing.reduce((s, d) => s + d.missingHours, 0);
+          return { author, missing, missingHours };
+        } catch (error) {
+          return { author, missingHours: 0, error: formatError(error) };
+        }
+      },
+    );
+
+    const withMissing = perUser
+      .filter((u) => (u.missing?.length ?? 0) > 0)
+      .sort((a, b) => b.missingHours - a.missingHours);
+    const clean = perUser.filter((u) => u.missing && u.missing.length === 0);
+    const noSchedule = perUser.filter((u) => u.noSchedule);
+    const failed = perUser.filter((u) => u.error);
+
+    const partialIssueIds = new Set<string>();
+    for (const u of withMissing) {
+      for (const m of u.missing ?? []) {
+        for (const b of m.loggedBreakdown ?? []) {
+          if (b.issueId !== 'unknown') partialIssueIds.add(b.issueId);
+        }
+      }
+    }
+    const issueInfoMap =
+      partialIssueIds.size > 0
+        ? await getIssueInfoMap(jiraClient, Array.from(partialIssueIds))
+        : {};
+
+    const totalMissingHours = withMissing.reduce(
+      (s, u) => s + u.missingHours,
+      0,
+    );
+    const totalMissingDays = withMissing.reduce(
+      (s, u) => s + (u.missing?.length ?? 0),
+      0,
+    );
+
+    const userWord = authors.length === 1 ? 'user' : 'users';
+    const lines: string[] = [
+      `Missing worklogs · ${startDate} to ${endDate} · ${withMissing.length} of ${authors.length} ${userWord} below expected hours · total missing ${formatHours(totalMissingHours)}`,
+    ];
+
+    for (const u of withMissing) {
+      const days = u.missing ?? [];
+      const dayWord = days.length === 1 ? 'day' : 'days';
+      lines.push('');
+      lines.push(
+        `${u.author.label} — missing ${formatHours(u.missingHours)} across ${days.length} ${dayWord}`,
+      );
+      for (const d of days) {
+        const typeBadge = d.type === 'WORKING_DAY' ? '' : ` [${d.type}]`;
+        const holidayBadge = d.holiday ? ` (${d.holiday})` : '';
+        lines.push(
+          `  ${d.date}${typeBadge}${holidayBadge} — missing ${formatHours(d.missingHours)} (${formatHours(d.loggedHours)} of ${formatHours(d.expectedHours)} logged)`,
+        );
+        for (const b of d.loggedBreakdown ?? []) {
+          const info = issueInfoMap[b.issueId];
+          const label = info
+            ? info.summary
+              ? `${info.key} — ${info.summary}`
+              : info.key
+            : b.issueId === 'unknown'
+              ? 'Unknown issue'
+              : `Issue ${b.issueId}`;
+          lines.push(`      ${label}: ${formatHours(b.hours)}`);
+        }
+      }
+    }
+
+    if (clean.length > 0) {
+      lines.push('');
+      lines.push(
+        `All expected hours logged (${clean.length}): ${clean.map((u) => u.author.label).join(', ')}`,
+      );
+    }
+    if (noSchedule.length > 0) {
+      lines.push('');
+      lines.push(
+        `No workload schedule for this period (${noSchedule.length}): ${noSchedule.map((u) => u.author.label).join(', ')}`,
+      );
+    }
+    if (failed.length > 0) {
+      lines.push('');
+      lines.push('Could not check (schedule unavailable):');
+      for (const u of failed) {
+        lines.push(`  ${u.author.label}: ${u.error}`);
+      }
+    }
+
+    return {
+      content: [{ type: 'text', text: lines.join('\n') }],
+      metadata: {
+        totalMissingDays,
+        totalMissingHours,
+        startDate,
+        endDate,
+        users: perUser.map((u) => ({
+          accountId: u.author.accountId,
+          label: u.author.label,
+          missingDays: u.missing?.length ?? 0,
+          missingHours: u.missingHours,
+          ...(u.noSchedule ? { noSchedule: true } : {}),
+          ...(u.error ? { error: u.error } : {}),
+        })),
+      },
+    };
+  }
+
   return {
     async retrieveWorklogs(
       startDate: string,
       endDate: string,
+      filter?: AuthorFilter,
     ): Promise<ToolResponse> {
       try {
+        const authors = await resolveAuthors(filter);
         const { worklogs, pagesProcessed } = await fetchAllWorklogs(
           startDate,
           endDate,
+          authors?.map((a) => a.accountId),
         );
 
         if (worklogs.length === 0) {
@@ -234,7 +484,9 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
             content: [
               {
                 type: 'text',
-                text: 'No worklogs found for the specified date range.',
+                text: authors
+                  ? `No worklogs found for the specified users between ${startDate} and ${endDate}. ${VIEW_OTHERS_HINT}`
+                  : 'No worklogs found for the specified date range.',
               },
             ],
           };
@@ -243,6 +495,10 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
         const issueInfoMap = await getIssueInfoMap(
           jiraClient,
           extractWorklogIssueIds(worklogs),
+        );
+
+        const authorLabels = new Map(
+          (authors ?? []).map((a) => [a.accountId, a.label]),
         );
 
         const formattedContent = worklogs.map((worklog: any) => {
@@ -257,12 +513,49 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
           const attributesInfo = attributeValues?.length
             ? ` | Attributes: ${JSON.stringify(attributeValues)}`
             : '';
+          const authorInfo = authors
+            ? `Author: ${authorLabels.get(worklog.author?.accountId) || worklog.author?.accountId || 'Unknown'} | `
+            : '';
 
           return {
             type: 'text' as const,
-            text: `TempoWorklogId: ${tempoWorklogId} | IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date}${startTime ? ` | StartTime: ${startTime}` : ''} | Hours: ${timeSpentHours} | Description: ${description}${attributesInfo}`,
+            text: `${authorInfo}TempoWorklogId: ${tempoWorklogId} | IssueKey: ${issueKey} | IssueId: ${issueId} | Date: ${date}${startTime ? ` | StartTime: ${startTime}` : ''} | Hours: ${timeSpentHours} | Description: ${description}${attributesInfo}`,
           };
         });
+
+        if (authors) {
+          const perAuthor = new Map<
+            string,
+            { count: number; seconds: number }
+          >();
+          for (const w of worklogs) {
+            const id = w.author?.accountId ?? 'unknown';
+            const agg = perAuthor.get(id) ?? { count: 0, seconds: 0 };
+            agg.count += 1;
+            agg.seconds += Number(w.timeSpentSeconds ?? 0);
+            perAuthor.set(id, agg);
+          }
+
+          const userWord = authors.length === 1 ? 'user' : 'users';
+          const summaryLines = [
+            `Worklogs for ${authors.length} ${userWord} · ${startDate} to ${endDate} · ${worklogs.length} worklogs`,
+          ];
+          for (const author of authors) {
+            const agg = perAuthor.get(author.accountId);
+            summaryLines.push(
+              agg
+                ? `${author.label}: ${agg.count} worklogs · ${formatHours(agg.seconds / 3600)}`
+                : `${author.label}: no worklogs`,
+            );
+          }
+          if (authors.some((a) => !perAuthor.has(a.accountId))) {
+            summaryLines.push('', VIEW_OTHERS_HINT);
+          }
+          formattedContent.unshift({
+            type: 'text' as const,
+            text: summaryLines.join('\n'),
+          });
+        }
 
         return {
           content: formattedContent,
@@ -271,6 +564,12 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
             pagesProcessed,
             startDate,
             endDate,
+            ...(authors && {
+              users: authors.map((a) => ({
+                accountId: a.accountId,
+                label: a.label,
+              })),
+            }),
           },
         };
       } catch (error) {
@@ -585,11 +884,25 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
       startDate: string,
       endDate: string,
       minHoursPerDay?: number,
+      filter?: AuthorFilter,
     ): Promise<ToolResponse> {
       const rangeError = validateDateRange(startDate, endDate);
       if (rangeError) return rangeError;
 
+      const overrideSeconds =
+        minHoursPerDay !== undefined ? Math.round(minHoursPerDay * 3600) : null;
+
       try {
+        const authors = await resolveAuthors(filter);
+        if (authors) {
+          return await missingWorklogDaysForUsers(
+            startDate,
+            endDate,
+            overrideSeconds,
+            authors,
+          );
+        }
+
         const accountId = await jiraClient.getCurrentUserAccountId();
 
         const [schedule, { worklogs }] = await Promise.all([
@@ -614,52 +927,7 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
           };
         }
 
-        const loggedByDate = new Map<string, Map<string, number>>();
-        for (const w of worklogs) {
-          const date = w.startDate;
-          if (!date) continue;
-          const issueId = w.issue?.id ? String(w.issue.id) : 'unknown';
-          const issueMap = loggedByDate.get(date) ?? new Map<string, number>();
-          issueMap.set(
-            issueId,
-            (issueMap.get(issueId) ?? 0) + Number(w.timeSpentSeconds ?? 0),
-          );
-          loggedByDate.set(date, issueMap);
-        }
-
-        const overrideSeconds =
-          minHoursPerDay !== undefined
-            ? Math.round(minHoursPerDay * 3600)
-            : null;
-
-        const missing: MissingWorklogDay[] = [];
-        for (const day of schedule) {
-          if (day.requiredSeconds <= 0) continue;
-
-          const requiredSeconds = overrideSeconds ?? day.requiredSeconds;
-          const dayIssues = loggedByDate.get(day.date);
-          const loggedSeconds = dayIssues
-            ? Array.from(dayIssues.values()).reduce((s, v) => s + v, 0)
-            : 0;
-          if (loggedSeconds >= requiredSeconds) continue;
-
-          const breakdown = dayIssues
-            ? Array.from(dayIssues.entries()).map(([issueId, seconds]) => ({
-                issueId,
-                hours: seconds / 3600,
-              }))
-            : [];
-
-          missing.push({
-            date: day.date,
-            type: day.type,
-            expectedHours: requiredSeconds / 3600,
-            loggedHours: loggedSeconds / 3600,
-            missingHours: (requiredSeconds - loggedSeconds) / 3600,
-            ...(day.holiday?.name ? { holiday: day.holiday.name } : {}),
-            ...(breakdown.length > 0 ? { loggedBreakdown: breakdown } : {}),
-          });
-        }
+        const missing = computeMissingDays(schedule, worklogs, overrideSeconds);
 
         const partialIssueIds = new Set<string>();
         for (const m of missing) {
@@ -746,19 +1014,27 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
       startDate: string,
       endDate: string,
       groupBy: AnalyticsGroupBy = 'issue',
+      filter?: AuthorFilter,
     ): Promise<ToolResponse> {
       const rangeError = validateDateRange(startDate, endDate);
       if (rangeError) return rangeError;
 
       try {
-        const { worklogs } = await fetchAllWorklogs(startDate, endDate);
+        const authors = await resolveAuthors(filter);
+        const { worklogs } = await fetchAllWorklogs(
+          startDate,
+          endDate,
+          authors?.map((a) => a.accountId),
+        );
 
         if (worklogs.length === 0) {
           return {
             content: [
               {
                 type: 'text',
-                text: `No worklogs found between ${startDate} and ${endDate}.`,
+                text: authors
+                  ? `No worklogs found for the specified users between ${startDate} and ${endDate}. ${VIEW_OTHERS_HINT}`
+                  : `No worklogs found between ${startDate} and ${endDate}.`,
               },
             ],
             metadata: {
@@ -779,9 +1055,29 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
           );
         }
 
+        // Labels for the 'user' grouping: resolved-filter labels first, then a
+        // best-effort Jira lookup for any authors not covered by the filter.
+        const authorLabels: Record<string, string> = {};
+        if (groupBy === 'user') {
+          for (const a of authors ?? []) authorLabels[a.accountId] = a.label;
+          const unknownIds = [
+            ...new Set(
+              worklogs
+                .map((w: any) => w.author?.accountId)
+                .filter((id: any): id is string => !!id && !authorLabels[id]),
+            ),
+          ];
+          if (unknownIds.length > 0) {
+            const users = await jiraClient.getUsersByAccountIds(unknownIds);
+            for (const [id, user] of Object.entries(users)) {
+              authorLabels[id] = userLabel(user);
+            }
+          }
+        }
+
         const buckets = new Map<string, { seconds: number; count: number }>();
         for (const w of worklogs) {
-          const key = computeGroupKey(w, groupBy, issueInfoMap);
+          const key = computeGroupKey(w, groupBy, issueInfoMap, authorLabels);
           const bucket = buckets.get(key) ?? { seconds: 0, count: 0 };
           bucket.seconds += Number(w.timeSpentSeconds ?? 0);
           bucket.count += 1;
@@ -805,8 +1101,11 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
 
         const worklogWord = worklogs.length === 1 ? 'worklog' : 'worklogs';
         const groupWord = groups.length === 1 ? 'group' : 'groups';
+        const usersInfo = authors
+          ? ` · ${authors.length} ${authors.length === 1 ? 'user' : 'users'}`
+          : '';
         const lines: string[] = [
-          `Worklog analytics · ${startDate} to ${endDate} · grouped by ${groupBy}`,
+          `Worklog analytics · ${startDate} to ${endDate} · grouped by ${groupBy}${usersInfo}`,
           `Total: ${formatHours(totalHours)} across ${worklogs.length} ${worklogWord} in ${groups.length} ${groupWord}`,
           '',
         ];
@@ -831,6 +1130,12 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
             startDate,
             endDate,
             details: groups,
+            ...(authors && {
+              users: authors.map((a) => ({
+                accountId: a.accountId,
+                label: a.label,
+              })),
+            }),
           },
         };
       } catch (error) {
@@ -846,6 +1151,62 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
       }
     },
   };
+}
+
+/**
+ * Compare a user's schedule against their logged time and return the days
+ * that fall short. `overrideSeconds` replaces the schedule's required time
+ * per day when set; non-working days (requiredSeconds <= 0) are skipped
+ * either way.
+ */
+function computeMissingDays(
+  schedule: DaySchedule[],
+  worklogs: any[],
+  overrideSeconds: number | null,
+): MissingWorklogDay[] {
+  const loggedByDate = new Map<string, Map<string, number>>();
+  for (const w of worklogs) {
+    const date = w.startDate;
+    if (!date) continue;
+    const issueId = w.issue?.id ? String(w.issue.id) : 'unknown';
+    const issueMap = loggedByDate.get(date) ?? new Map<string, number>();
+    issueMap.set(
+      issueId,
+      (issueMap.get(issueId) ?? 0) + Number(w.timeSpentSeconds ?? 0),
+    );
+    loggedByDate.set(date, issueMap);
+  }
+
+  const missing: MissingWorklogDay[] = [];
+  for (const day of schedule) {
+    if (day.requiredSeconds <= 0) continue;
+
+    const requiredSeconds = overrideSeconds ?? day.requiredSeconds;
+    const dayIssues = loggedByDate.get(day.date);
+    const loggedSeconds = dayIssues
+      ? Array.from(dayIssues.values()).reduce((s, v) => s + v, 0)
+      : 0;
+    if (loggedSeconds >= requiredSeconds) continue;
+
+    const breakdown = dayIssues
+      ? Array.from(dayIssues.entries()).map(([issueId, seconds]) => ({
+          issueId,
+          hours: seconds / 3600,
+        }))
+      : [];
+
+    missing.push({
+      date: day.date,
+      type: day.type,
+      expectedHours: requiredSeconds / 3600,
+      loggedHours: loggedSeconds / 3600,
+      missingHours: (requiredSeconds - loggedSeconds) / 3600,
+      ...(day.holiday?.name ? { holiday: day.holiday.name } : {}),
+      ...(breakdown.length > 0 ? { loggedBreakdown: breakdown } : {}),
+    });
+  }
+
+  return missing;
 }
 
 /**
@@ -901,6 +1262,7 @@ function computeGroupKey(
   worklog: any,
   groupBy: AnalyticsGroupBy,
   issueInfoMap: Record<string, { key: string; summary: string }>,
+  authorLabels: Record<string, string> = {},
 ): string {
   switch (groupBy) {
     case 'issue': {
@@ -915,6 +1277,11 @@ function computeGroupKey(
         (a: { key: string }) => a.key === '_Account_',
       );
       return accountAttr?.value || 'No account';
+    }
+    case 'user': {
+      const accountId = worklog.author?.accountId;
+      if (!accountId) return 'Unknown user';
+      return authorLabels[accountId] || accountId;
     }
     case 'day':
       return worklog.startDate || 'Unknown date';

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,10 +72,42 @@ export const worklogEntrySchema = z.object({
 
 export type WorklogEntry = z.infer<typeof worklogEntrySchema>;
 
+// Author filter — lets the read tools target other users' worklogs instead of
+// the token owner's. All fields resolve to Jira accountIds and are unioned
+// when combined. Tempo enforces permissions server-side: worklogs the token
+// owner may not view are silently omitted from results.
+export const authorFilterShape = {
+  users: z
+    .array(z.string().min(1))
+    .optional()
+    .describe(
+      'Fetch worklogs of these users instead of your own. Each entry may be an email, a display name, or a Jira accountId.',
+    ),
+  program: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Fetch worklogs of all current members of this Tempo Program (name or numeric id).',
+    ),
+  team: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Fetch worklogs of all current members of this Tempo Team (name or numeric id).',
+    ),
+};
+
+export const authorFilterSchema = z.object(authorFilterShape);
+
+export type AuthorFilter = z.infer<typeof authorFilterSchema>;
+
 // MCP tool schemas
 export const retrieveWorklogsSchema = z.object({
   startDate: dateSchema(),
   endDate: dateSchema(),
+  ...authorFilterShape,
 });
 
 export const createWorklogSchema = z.object({
@@ -113,11 +145,13 @@ export const getMissingWorklogDaysSchema = z.object({
     .number()
     .positive('minHoursPerDay must be positive')
     .optional(),
+  ...authorFilterShape,
 });
 
 export const analyticsGroupBySchema = z.enum([
   'issue',
   'account',
+  'user',
   'day',
   'week',
   'month',
@@ -129,6 +163,7 @@ export const getWorklogAnalyticsSchema = z.object({
   startDate: dateSchema(),
   endDate: dateSchema(),
   groupBy: analyticsGroupBySchema.optional().default('issue'),
+  ...authorFilterShape,
 });
 
 // API interfaces
@@ -136,6 +171,8 @@ export interface JiraUser {
   accountId: string;
   emailAddress?: string;
   displayName?: string;
+  /** 'atlassian' for humans; 'app' / 'customer' accounts can't log Tempo time. */
+  accountType?: string;
 }
 
 export interface TempoWorklog {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,92 @@
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import { JiraClient } from './jira.js';
 
 /**
  * Standard error handling for API errors
- * Extracts the most useful error message from Axios errors
+ * Extracts the most useful error message from Axios errors.
+ * Tempo wraps messages as { errors: [{ message }] }, Jira as
+ * { errorMessages: [...] } or { message } — check all three before falling
+ * back to Axios' generic "Request failed with status code N".
  */
 export function formatError(error: unknown): string {
   if (axios.isAxiosError(error)) {
-    return (error.response?.data as any)?.message || error.message;
+    const data = error.response?.data as any;
+    const tempoErrors = Array.isArray(data?.errors)
+      ? data.errors
+          .map((e: any) => e?.message)
+          .filter(Boolean)
+          .join('; ')
+      : '';
+    const jiraErrors = Array.isArray(data?.errorMessages)
+      ? data.errorMessages.join(', ')
+      : '';
+    return data?.message || tempoErrors || jiraErrors || error.message;
   }
   return (error as Error).message;
+}
+
+/**
+ * Run an async mapper over items with bounded concurrency.
+ * Preserves input order in the returned array. Used to keep multi-user
+ * fan-out (schedules, issue lookups, team members) under Jira/Tempo rate
+ * limits instead of firing an unbounded Promise.all.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    async () => {
+      while (nextIndex < items.length) {
+        const current = nextIndex++;
+        results[current] = await fn(items[current], current);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * Fetch every page of a paginated Tempo GET endpoint by following
+ * `metadata.next`. The next URLs are absolute, which makes Axios ignore the
+ * instance baseURL while still applying its auth headers.
+ */
+export async function fetchAllTempoPages(
+  api: AxiosInstance,
+  path: string,
+  params: Record<string, unknown>,
+  maxPages = 500,
+): Promise<any[]> {
+  let all: any[] = [];
+  let nextUrl: string | null = null;
+  let isFirstRequest = true;
+  let pageCount = 0;
+
+  do {
+    if (pageCount >= maxPages) {
+      throw new Error(
+        `Reached maximum page limit (${maxPages}) while fetching ${path}.`,
+      );
+    }
+    let response;
+    if (isFirstRequest) {
+      response = await api.get(path, { params });
+      isFirstRequest = false;
+    } else {
+      response = await api.get(nextUrl!);
+    }
+
+    all = all.concat(response.data?.results || []);
+    nextUrl = response.data?.metadata?.next || null;
+    pageCount++;
+  } while (nextUrl);
+
+  return all;
 }
 
 /**
@@ -40,17 +117,15 @@ export async function getIssueInfoMap(
   if (unique.length === 0) return {};
 
   const map: Record<string, { key: string; summary: string }> = {};
-  await Promise.all(
-    unique.map(async (issueId) => {
-      try {
-        map[issueId] = await jira.getIssueInfoById(issueId);
-      } catch (error) {
-        console.error(
-          `Could not get info for issue ID ${issueId}: ${(error as Error).message}`,
-        );
-      }
-    }),
-  );
+  await mapWithConcurrency(unique, 8, async (issueId) => {
+    try {
+      map[issueId] = await jira.getIssueInfoById(issueId);
+    } catch (error) {
+      console.error(
+        `Could not get info for issue ID ${issueId}: ${(error as Error).message}`,
+      );
+    }
+  });
 
   return map;
 }


### PR DESCRIPTION
retrieveWorklogs, getWorklogAnalytics and getMissingWorklogDays now accept
optional filters: users (emails, display names, or accountIds), program and
team (Tempo program/team name or id, expanded to current members). Resolved
authorIds are queried via POST /4/worklogs/search with offset pagination.
- getWorklogAnalytics: new groupBy "user" for per-person reports
- getMissingWorklogDays: per-user report sorted by most missing hours
- email resolution falls back to display-name matching when Jira privacy
  settings hide emails from search
- program resolution falls back to visible teams when the token lacks
  program-view permission
- Tempo error bodies (errors[].message) surfaced instead of generic axios
  "status code" messages