### PR TITLE
Review follow-ups for #28: paginate /programs, flag hidden worklogs in missing-days report

### DIFF
--- a/src/authors.ts
+++ b/src/authors.ts
@@ -164,8 +164,7 @@ async function resolveProgramTeamIds(
 ): Promise<number[]> {
   let programs: NamedRef[];
   try {
-    const response = await tempo.get('/programs');
-    programs = response.data?.results || [];
+    programs = await fetchAllTempoPages(tempo, '/programs', { limit: 100 });
   } catch (error) {
     throwWithTeamsScopeHint(error, 'programs');
   }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -446,6 +446,15 @@ export function createTools(ctx: Ctx, jira?: JiraClient): Tools {
       }
     }
 
+    // A user whose schedule is visible but whose worklogs are hidden by Tempo
+    // permissions would otherwise read as "logged nothing" — a false signal.
+    if (authors.some((a) => !worklogsByAuthor.has(a.accountId))) {
+      lines.push('');
+      lines.push(
+        `Some users have no visible worklogs in this range. ${VIEW_OTHERS_HINT}`,
+      );
+    }
+
     return {
       content: [{ type: 'text', text: lines.join('\n') }],
       metadata: {


### PR DESCRIPTION
Two small follow-ups from the review of #28:

- `resolveProgramTeamIds` now pages through `GET /programs` via `fetchAllTempoPages` instead of reading only the first page, so programs beyond Tempo's default page size can still be matched.
- The multi-user `getMissingWorklogDays` report appends the "Tempo silently omits worklogs" permission hint when any requested user has zero visible worklogs, so a permission gap is not misread as a person who logged nothing.

Verified: `npm run lint -- --quiet`, `npm run format:check`, `npm run build`, `npm run remote:typecheck` all pass.