### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ivelin-web/tempo-mcp-server",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ivelin-web/tempo-mcp-server",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivelin-web/tempo-mcp-server",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "MCP server for managing Tempo worklogs in Jira",
   "main": "build/index.js",
   "type": "module",


### PR DESCRIPTION
Version bump for the 1.8.0 release: multi-user worklog filters (users, program, team) for the read tools + groupBy: user analytics (#28, #29).