### PR TITLE
fix: normalize bin path so npm publish keeps the CLI binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "type": "module",
   "bin": {
-    "tempo-mcp-server": "./build/index.js"
+    "tempo-mcp-server": "build/index.js"
   },
   "scripts": {
     "build": "tsc -p tsconfig.node.json && node -e \"require('fs').chmodSync('build/index.js', '755')\"",


### PR DESCRIPTION
The npm version bundled with Node 24 in CI treats the `./` prefix in bin paths as invalid and silently strips the `bin` entry at publish time (visible in the v1.8.0 publish run log: `"bin[tempo-mcp-server]" script name build/index.js was invalid and removed`). A published package without `bin` breaks `npx @ivelin-web/tempo-mcp-server` for everyone. This is the output of `npm pkg fix`.